### PR TITLE
Fix question item with no title [#136195417]

### DIFF
--- a/lib/blacklight/models/question.rb
+++ b/lib/blacklight/models/question.rb
@@ -73,7 +73,8 @@ module Blacklight
       @question_type = QUESTION_TYPE[@blackboard_type]
       @question = CanvasCc::CanvasCC::Models::Question.create(@question_type)
       @points_possible = data.at("qmd_absolutescore_max").text
-      @title = data.attributes["title"].value
+      title = data.attributes["title"]
+      @title = title ? title.value : ""
       iterate_item(data)
       self
     end


### PR DESCRIPTION
This ensures that a title was found before grabbing the value from it.