### PR TITLE
Fix several small things

### DIFF
--- a/lib/blacklight.rb
+++ b/lib/blacklight.rb
@@ -54,12 +54,11 @@ module Blacklight
     course
   end
 
-  def self.initialize_course(canvas_file_path, blackboard_file_path = nil)
+  def self.initialize_course(canvas_file_path, blackboard_file_path)
     metadata = Blacklight::CanvasCourse.metadata_from_file(canvas_file_path)
-    bb_zip = if blackboard_file_path
-               Zip::File.open(blackboard_file_path)
-             end
-    course = Blacklight::CanvasCourse.from_metadata(metadata, bb_zip)
-    course.upload_content(canvas_file_path)
+    Zip::File.open(blackboard_file_path, "rb") do |bb_zip|
+      course = Blacklight::CanvasCourse.from_metadata(metadata, bb_zip)
+      course.upload_content(canvas_file_path)
+    end
   end
 end

--- a/lib/blacklight/canvas_course.rb
+++ b/lib/blacklight/canvas_course.rb
@@ -163,23 +163,25 @@ module Blacklight
     end
 
     def upload_to_s3(migration, filename)
-      # Attach the file to the S3 auth
-      pre_attachment = migration.pre_attachment
-      upload_url = pre_attachment["upload_url"]
-      upload_params = pre_attachment["upload_params"]
-      upload_params[:file] = File.new(filename, "rb")
+      File.open(filename, "rb") do |file|
+        # Attach the file to the S3 auth
+        pre_attachment = migration.pre_attachment
+        upload_url = pre_attachment["upload_url"]
+        upload_params = pre_attachment["upload_params"]
+        upload_params[:file] = file
 
-      # Post to S3
-      RestClient.post(
-        upload_url,
-        upload_params,
-      ) do |response|
-        # Post to Canvas
+        # Post to S3
         RestClient.post(
-          response.headers[:location],
-          nil,
-          Authorization: "Bearer #{Blacklight.canvas_token}",
-        )
+          upload_url,
+          upload_params,
+        ) do |response|
+          # Post to Canvas
+          RestClient.post(
+            response.headers[:location],
+            nil,
+            Authorization: "Bearer #{Blacklight.canvas_token}",
+          )
+        end
       end
     end
   end

--- a/lib/blacklight/canvas_course.rb
+++ b/lib/blacklight/canvas_course.rb
@@ -150,12 +150,14 @@ module Blacklight
 
       puts "Uploading: #{name}"
       upload_to_s3(migration, filename)
+      puts "Done uploading: #{name}"
+
+      puts "Creating Scorm: #{name}"
       create_scorm_assignments(
         upload_scorm_packages(@scorm_packages),
         @course_resource.id,
       )
-
-      puts "Done uploading: #{name}"
+      puts "Done creating scorm: #{name}"
     end
 
     def upload_to_s3(migration, filename)

--- a/lib/blacklight/canvas_course.rb
+++ b/lib/blacklight/canvas_course.rb
@@ -73,8 +73,8 @@ module Blacklight
     # uploaded to a scorm manager
     ##
     def create_scorm_assignment(scorm_package, course_id)
-      url = "#{Blacklight.scorm_launch_url}?" +
-        "course_id=#{scorm_package['package_id']}"
+      url = Blacklight.scorm_launch_url +
+        "?course_id=#{scorm_package['package_id']}"
 
       payload = {
         assignment__submission_types__: ["external_tool"],

--- a/lib/blacklight/canvas_course.rb
+++ b/lib/blacklight/canvas_course.rb
@@ -15,16 +15,7 @@ module Blacklight
     def initialize(metadata, course_resource, blackboard_export)
       @metadata = metadata
       @course_resource = course_resource
-      @scorm_packages = CanvasCourse.get_scorm_packages(blackboard_export)
-    end
-
-    ##
-    # Extracts scorm packages from a blackboard export zip file
-    ##
-    def self.get_scorm_packages(blackboard_export)
-      ScormPackage.find_scorm_manifests(blackboard_export).map do |manifest|
-        ScormPackage.new blackboard_export, manifest
-      end
+      @scorm_packages = ScormPackage.get_scorm_packages(blackboard_export)
     end
 
     ##

--- a/lib/blacklight/canvas_course.rb
+++ b/lib/blacklight/canvas_course.rb
@@ -100,16 +100,18 @@ module Blacklight
     ##
     def upload_scorm_package(scorm_package, course_id, tmp_name)
       zip = scorm_package.write_zip tmp_name
-      RestClient.post(
-        "#{Blacklight.scorm_url}/api/scorm_courses",
-        {
-          oauth_consumer_key: "scorm-player",
-          lms_course_id: course_id,
-          file: File.new(zip, "rb"),
-        },
-        SharedAuthorization: Blacklight.scorm_shared_auth,
-      ) do |resp|
-        JSON.parse(resp.body)["response"]
+      File.open(zip, "rb") do |file|
+        RestClient.post(
+          "#{Blacklight.scorm_url}/api/scorm_courses",
+          {
+            oauth_consumer_key: "scorm-player",
+            lms_course_id: course_id,
+            file: file,
+          },
+          SharedAuthorization: Blacklight.scorm_shared_auth,
+        ) do |resp|
+          JSON.parse(resp.body)["response"]
+        end
       end
     end
 

--- a/lib/blacklight/models/file.rb
+++ b/lib/blacklight/models/file.rb
@@ -2,6 +2,7 @@ require "blacklight/exceptions"
 module Blacklight
   class BlacklightFile
     attr_accessor(:id, :location, :name)
+    @@dir = nil
 
     def initialize(zip_entry)
       path = zip_entry.name
@@ -38,7 +39,6 @@ module Blacklight
     # Remove temporary files
     ##
     def self.cleanup
-      @@dir ||= nil
       FileUtils.rm_r @@dir unless @@dir.nil?
     end
   end

--- a/lib/blacklight/models/scorm_package.rb
+++ b/lib/blacklight/models/scorm_package.rb
@@ -32,6 +32,15 @@ module Blacklight
     end
 
     ##
+    # Extracts scorm packages from a blackboard export zip file
+    ##
+    def self.get_scorm_packages(blackboard_export)
+      find_scorm_manifests(blackboard_export).map do |manifest|
+        ScormPackage.new blackboard_export, manifest
+      end
+    end
+
+    ##
     # Returns array of all scorm manifest files inside of blackboard export
     ##
     def self.find_scorm_manifests(zip_file)

--- a/lib/blacklight/models/scorm_package.rb
+++ b/lib/blacklight/models/scorm_package.rb
@@ -24,7 +24,10 @@ module Blacklight
         text.delete(" ").downcase
       return schema_name == SCORM_SCHEMA
     # NOTE we occasionally run into malformed manifest files
-    rescue Nokogiri::XML::XPath::SyntaxError
+    rescue Nokogiri::XML::XPath::SyntaxError => e
+      filename = manifest.zipfile
+      STDERR.puts "Malformed scorm manifest found: #{manifest} in #{filename}"
+      STDERR.puts e.to_s
       false
     end
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,7 +1,11 @@
 def get_fixture(name)
-  File.open("#{File.dirname(__FILE__)}/fixtures/#{name}")
+  File.open("#{File.dirname(__FILE__)}/fixtures/#{name}") do |file|
+    yield file
+  end
 end
 
 def get_fixture_xml(name)
-  Nokogiri::XML(get_fixture(name))
+  get_fixture(name) do |file|
+    Nokogiri::XML(file)
+  end
 end

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -4,6 +4,18 @@ def get_fixture(name)
   end
 end
 
+def get_zip_fixture(name)
+  Zip::File.open("#{File.dirname(__FILE__)}/fixtures/#{name}") do |file|
+    yield file
+  end
+end
+
+def get_zip_manifest(name)
+  get_zip_fixture(name) do |file|
+    return file, get_manifest_entry(file)
+  end
+end
+
 def get_fixture_xml(name)
   get_fixture(name) do |file|
     Nokogiri::XML(file)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -12,7 +12,7 @@ end
 
 def get_zip_manifest(name)
   get_zip_fixture(name) do |file|
-    return file, get_manifest_entry(file)
+    yield file, get_manifest_entry(file)
   end
 end
 

--- a/spec/helpers/spec_helper.rb
+++ b/spec/helpers/spec_helper.rb
@@ -18,5 +18,5 @@ def stub_toe(type, pattern, json, with_params = nil)
 end
 
 def stub_active_courses_in_account(json)
-  stub_toe(:get, /v1\/accounts\/self\/courses/, json)
+  stub_toe(:get, /v1\/accounts\/.+\/courses/, json)
 end

--- a/spec/models/scorm_package_spec.rb
+++ b/spec/models/scorm_package_spec.rb
@@ -12,32 +12,33 @@ end
 
 describe "ScormPackage" do
   it "should find all entries in same directory as manifest" do
-    zip, manifest = get_zip_manifest("scorm_package.zip")
-
-    result = Blacklight::ScormPackage.get_entries(zip, manifest)
-    assert_equal(result.size, 2)
-    assert_equal(
-      manifest.get_input_stream.read.include?("ADL SCORM"),
-      true,
-    )
+    get_zip_manifest("scorm_package.zip") do |zip, manifest|
+      result = Blacklight::ScormPackage.get_entries(zip, manifest)
+      assert_equal(result.size, 2)
+      assert_equal(
+        manifest.get_input_stream.read.include?("ADL SCORM"),
+        true,
+      )
+    end
   end
 
   it "should convert to zip file" do
-    zip, manifest = get_zip_manifest("scorm_package.zip")
-    package = Blacklight::ScormPackage.new(zip, manifest)
-    EXPORT_NAME = "zip_export.zip".freeze
-    begin
-      result_location = package.write_zip(EXPORT_NAME)
-      result_manifest = Zip::File.open(result_location) do |file|
-        get_manifest_entry(file)
-      end
+    get_zip_manifest("scorm_package.zip") do |zip, manifest|
+      package = Blacklight::ScormPackage.new(zip, manifest)
+      EXPORT_NAME = "zip_export.zip".freeze
+      begin
+        result_location = package.write_zip(EXPORT_NAME)
+        Zip::File.open(result_location) do |file|
+          result_manifest = get_manifest_entry(file)
 
-      assert_equal(
-        result_manifest.get_input_stream.read.include?("ADL SCORM"),
-        true,
-      )
-    ensure
-      Blacklight::ScormPackage.cleanup # Remove temp files
+          assert_equal(
+            result_manifest.get_input_stream.read.include?("ADL SCORM"),
+            true,
+          )
+        end
+      ensure
+        Blacklight::ScormPackage.cleanup # Remove temp files
+      end
     end
   end
 

--- a/spec/models/scorm_package_spec.rb
+++ b/spec/models/scorm_package_spec.rb
@@ -12,8 +12,7 @@ end
 
 describe "ScormPackage" do
   it "should find all entries in same directory as manifest" do
-    zip = Zip::File.new("spec/fixtures/scorm_package.zip")
-    manifest = get_manifest_entry zip
+    zip, manifest = get_zip_manifest("scorm_package.zip")
 
     result = Blacklight::ScormPackage.get_entries(zip, manifest)
     assert_equal(result.size, 2)
@@ -24,13 +23,14 @@ describe "ScormPackage" do
   end
 
   it "should convert to zip file" do
-    zip = Zip::File.new("spec/fixtures/scorm_package.zip")
-    package = Blacklight::ScormPackage.new(zip, get_manifest_entry(zip))
+    zip, manifest = get_zip_manifest("scorm_package.zip")
+    package = Blacklight::ScormPackage.new(zip, manifest)
     EXPORT_NAME = "zip_export.zip".freeze
     begin
       result_location = package.write_zip(EXPORT_NAME)
-      result_zip = Zip::File.new(result_location)
-      result_manifest = get_manifest_entry(result_zip)
+      result_manifest = Zip::File.open(result_location) do |file|
+        get_manifest_entry(file)
+      end
 
       assert_equal(
         result_manifest.get_input_stream.read.include?("ADL SCORM"),


### PR DESCRIPTION
Write to STDERR when scorm manifest is malformed
Don’t interpolate the launch_url
Improve logging when uploading and creating scorm packages
Open file in a block to auto close it when posting to scorm server
Open file in a block to auto close it when posting to s3
Move get_scorm_packages to scorm_package.rb
Set `@@dir` to nil on the class instead of in a method
Open blackboard zip in a block. File will always be there from the rake tasks as they depend on it being there. So don’t check that the file exists.
Fix spec helper to accept any course in the stub
Fix specs to close fixtures