### PR TITLE
Add page url link to the body

### DIFF
--- a/lib/blacklight/models/content.rb
+++ b/lib/blacklight/models/content.rb
@@ -36,6 +36,7 @@ module Blacklight
     def iterate_xml(xml, pre_data)
       @points = pre_data[:points] || 0
       @title = xml.xpath("/CONTENT/TITLE/@value").first.text
+      @url = xml.at("URL")["value"]
       @body = xml.xpath("/CONTENT/BODY/TEXT").first.text
       @type = xml.xpath("/CONTENT/RENDERTYPE/@value").first.text
       @parent_id = pre_data[:parent_id]

--- a/lib/blacklight/models/wikipage.rb
+++ b/lib/blacklight/models/wikipage.rb
@@ -8,6 +8,14 @@ module Blacklight
           select { |p| p.title.start_with? @title }.count
         @title = "#{@title}-#{page_count + 1}" if page_count > 0
         page = CanvasCc::CanvasCC::Models::Page.new
+        if !@url.empty?
+          @body = %{
+            <a href="#{@url}">
+              #{@url}
+            </a>
+            #{@body}
+          }
+        end
         page.body = fix_html(@body, resources)
         page.identifier = @id
         page.page_name = @title


### PR DESCRIPTION
Some pages have a url in the title as a clickable link.
Canvas doesn’t support that, so just prepend that link to the body.

From blackboard:
![image](https://cloud.githubusercontent.com/assets/1216167/21438853/4ecb105a-c848-11e6-8b28-a1cd827a3a51.png)
`Step 2: Video clip from The Hurt Locker` is a link to vimeo.

Now in canvas:
![image](https://cloud.githubusercontent.com/assets/1216167/21438959/c245b698-c848-11e6-911d-d7de8d152d43.png)
