### PR TITLE
Fix fill in the blank answers

### DIFF
--- a/lib/blacklight/models/questions/fill_in_blank.rb
+++ b/lib/blacklight/models/questions/fill_in_blank.rb
@@ -3,9 +3,12 @@ module Blacklight
     def iterate_xml(data)
       super
       conditionvar = data.at("resprocessing").at("conditionvar")
-      answer = Answer.new(conditionvar.at("varequal").text)
-      answer.fraction = @max_score
-      @answers.push(answer)
+      # not all fill in the blank questions have answers(ie: surveys)
+      if conditionvar
+        answer = Answer.new(conditionvar.at("varequal").text)
+        answer.fraction = @max_score
+        @answers.push(answer)
+      end
       self
     end
   end

--- a/lib/blacklight/models/questions/fill_in_blank_plus.rb
+++ b/lib/blacklight/models/questions/fill_in_blank_plus.rb
@@ -3,12 +3,15 @@ module Blacklight
     def iterate_xml(data)
       super
       conditionvar = data.at("resprocessing").at("conditionvar")
-      conditionvar.at("and").children.each do |or_child|
-        or_child.children.each do |varequal|
-          answer = Answer.new(varequal.text)
-          answer.resp_ident = varequal.attributes["respident"].value
-          answer.fraction = @max_score
-          @answers.push(answer)
+      # not all fill in the blank questions have answers(ie: surveys)
+      if conditionvar
+        conditionvar.at("and").children.each do |or_child|
+          or_child.children.each do |varequal|
+            answer = Answer.new(varequal.text)
+            answer.resp_ident = varequal.attributes["respident"].value
+            answer.fraction = @max_score
+            @answers.push(answer)
+          end
         end
       end
       self


### PR DESCRIPTION
Make sure an answer is found for fill in the blank. Surveys don't have an answer text, so none will be found.