### PR TITLE
Fix colliding uploads

### DIFF
--- a/lib/senkyoshi/canvas_course.rb
+++ b/lib/senkyoshi/canvas_course.rb
@@ -48,14 +48,12 @@ module Senkyoshi
     ##
     def self.from_metadata(metadata, blackboard_export = nil)
       course_name = metadata[:name] || metadata[:title]
-      courses = client.list_active_courses_in_account(Senkyoshi.account_id)
-      canvas_course = courses.detect { |course| course.name == course_name } ||
-        client.create_new_course(
-          Senkyoshi.account_id,
-          course: {
-            name: course_name,
-          },
-        )
+      canvas_course = client.create_new_course(
+        Senkyoshi.account_id,
+        course: {
+          name: course_name,
+        },
+      )
       CanvasCourse.new(metadata, canvas_course, blackboard_export)
     end
 

--- a/spec/canvas_course_spec.rb
+++ b/spec/canvas_course_spec.rb
@@ -1,6 +1,7 @@
 require "minitest/autorun"
 require "senkyoshi/canvas_course"
 require_relative "helpers/spec_helper"
+require_relative "mocks/mock_client.rb"
 
 include Senkyoshi
 
@@ -16,10 +17,11 @@ describe Senkyoshi::CanvasCourse do
   describe "from_metadata" do
     it "should return a canvas course" do
       name = "bfcoding 101"
-      stub_active_courses_in_account([{ name: name }])
-      metadata = { name: name }
-      course = Senkyoshi::CanvasCourse.from_metadata(metadata)
-      assert_kind_of Senkyoshi::CanvasCourse, course
+      CanvasCourse.stub(:client, MockClient.new) do
+        metadata = { name: name }
+        course = Senkyoshi::CanvasCourse.from_metadata(metadata)
+        assert_kind_of Senkyoshi::CanvasCourse, course
+      end
     end
   end
 end

--- a/spec/mocks/mock_client.rb
+++ b/spec/mocks/mock_client.rb
@@ -1,0 +1,3 @@
+class MockClient
+  def create_new_course(*) end
+end


### PR DESCRIPTION
* Removes check to see if course exists before creating a new course

Previously there was a check to see if a course already existed with the same title, because titles aren't unique this resulted in missing courses when there were colliding titles.

These are different courses that have the same title: 
<img width="440" alt="screen shot 2017-01-05 at 11 20 58 am" src="https://cloud.githubusercontent.com/assets/9383215/21692244/233b92ce-d339-11e6-992d-0fec5edf2c2a.png">
