### PR TITLE
Preserves the Blackboard File Structure [#137113977]

### DIFF
--- a/lib/senkyoshi.rb
+++ b/lib/senkyoshi.rb
@@ -12,7 +12,6 @@ require "zip"
 require "senkyoshi/exceptions"
 
 module Senkyoshi
-  IMPORTED_FILES_DIRNAME = "Imported".freeze
   BASE = "$IMS-CC-FILEBASE$".freeze
 
   def self.parse(zip_path, imscc_path)

--- a/lib/senkyoshi/models/content_file.rb
+++ b/lib/senkyoshi/models/content_file.rb
@@ -27,9 +27,9 @@ module Senkyoshi
     end
 
     def canvas_conversion(canvas_file = nil)
-      @linkname = ContentFile.correct_linkname(canvas_file) if canvas_file
+      path = canvas_file ? canvas_file.file_path : @linkname
       query = "?canvas_download=1&amp;canvas_qs_wrap=1"
-      href = "$IMS_CC_FILEBASE$/#{IMPORTED_FILES_DIRNAME}/#{@linkname}#{query}"
+      href = "$IMS_CC_FILEBASE$/#{path}#{query}"
       %{
         <a
           class="instructure_scribd_file instructure_file_link"

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -65,14 +65,15 @@ module Senkyoshi
     ##
     # Determine whether or not a file is a metadata file or not
     ##
-    def self.metadata_file?(file_names, file)
+    def self.metadata_file?(entry_names, file)
       if File.extname(file.name) == ".xml"
         # Detect and skip metadata files.
-        concrete_file = File.join(
+        non_meta_file = File.join(
           File.dirname(file.name),
           File.basename(file.name, ".xml"),
         )
-        file_names.include?(concrete_file)
+
+        entry_names.include?(non_meta_file)
       else
         false
       end
@@ -90,9 +91,9 @@ module Senkyoshi
     ##
     # Determine if a file should be included in course files or not
     ##
-    def self.valid_file?(file_names, scorm_paths, file)
+    def self.valid_file?(entry_names, scorm_paths, file)
       return false if SenkyoshiFile.blacklisted? file
-      return false if SenkyoshiFile.metadata_file? file_names, file
+      return false if SenkyoshiFile.metadata_file? entry_names, file
       return false if SenkyoshiFile.belongs_to_scorm_package? scorm_paths, file
       true
     end

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -10,12 +10,8 @@ module Senkyoshi
       "*.dat",
     ].freeze
 
-    # Blackboard course files and folders are located at this file path. They
-    # have no meaning in canvas, so we remove them
-    BLACKBOARD_FILE_PREFIX = "csfiles/home_dir/".freeze
-
     def initialize(zip_entry)
-      @path = strip_xid zip_entry.name.gsub(BLACKBOARD_FILE_PREFIX, "")
+      @path = strip_xid zip_entry.name
       @location = extract_file(zip_entry) # Location of file on local filesystem
 
       base_name = File.basename(zip_entry.name)

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -3,7 +3,7 @@ require "senkyoshi/exceptions"
 
 module Senkyoshi
   class SenkyoshiFile < Resource
-    attr_accessor(:xid, :location, :name)
+    attr_accessor(:xid, :location, :name, :path)
     @@dir = nil
 
     FILE_BLACKLIST = [
@@ -14,7 +14,7 @@ module Senkyoshi
       @path = zip_entry.name.gsub(/__xid-[0-9]+_[0-9]+/, "")
       @location = extract_file(zip_entry) # Location of file on local filesystem
 
-      base_name = File.basename(@path)
+      base_name = File.basename(zip_entry.name)
       @xid = base_name[/__(xid-[0-9]+_[0-9]+)/, 1] ||
         Senkyoshi.create_random_hex
     end
@@ -37,7 +37,7 @@ module Senkyoshi
       file = CanvasCc::CanvasCC::Models::CanvasFile.new
       file.identifier = @xid
       file.file_location = @location
-      file.file_path = "#{IMPORTED_FILES_DIRNAME}/#{@path}"
+      file.file_path = @path
       file.hidden = false
 
       course.files << file

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -10,13 +10,21 @@ module Senkyoshi
       "*.dat",
     ].freeze
 
+    # Blackboard course files and folders are located at this file path. They
+    # have no meaning in canvas, so we remove them
+    BLACKBOARD_FILE_PREFIX = "csfiles/home_dir/".freeze
+
     def initialize(zip_entry)
-      @path = zip_entry.name.gsub(/__xid-[0-9]+_[0-9]+/, "")
+      @path = strip_xid zip_entry.name.gsub(BLACKBOARD_FILE_PREFIX, "")
       @location = extract_file(zip_entry) # Location of file on local filesystem
 
       base_name = File.basename(zip_entry.name)
       @xid = base_name[/__(xid-[0-9]+_[0-9]+)/, 1] ||
         Senkyoshi.create_random_hex
+    end
+
+    def strip_xid(name)
+      name.gsub(/__xid-[0-9]+_[0-9]+/, "")
     end
 
     def matches_xid?(xid)

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -11,13 +11,12 @@ module Senkyoshi
     ].freeze
 
     def initialize(zip_entry)
-      path = zip_entry.name
-      base_name = File.basename(path)
+      @path = zip_entry.name.gsub(/__xid-[0-9]+_[0-9]+/, "")
+      @location = extract_file(zip_entry) # Location of file on local filesystem
 
+      base_name = File.basename(@path)
       @xid = base_name[/__(xid-[0-9]+_[0-9]+)/, 1] ||
         Senkyoshi.create_random_hex
-      @name = base_name.gsub(/__xid-[0-9]+_[0-9]+/, "")
-      @location = extract_file(zip_entry) # Location of file on local filesystem
     end
 
     def matches_xid?(xid)
@@ -38,7 +37,7 @@ module Senkyoshi
       file = CanvasCc::CanvasCC::Models::CanvasFile.new
       file.identifier = @xid
       file.file_location = @location
-      file.file_path = "#{IMPORTED_FILES_DIRNAME}/#{@name}"
+      file.file_path = "#{IMPORTED_FILES_DIRNAME}/#{@path}"
       file.hidden = false
 
       course.files << file

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -3,7 +3,7 @@ require "senkyoshi/exceptions"
 
 module Senkyoshi
   class SenkyoshiFile < Resource
-    attr_accessor(:xid, :location, :name, :path)
+    attr_accessor(:xid, :location, :path)
     @@dir = nil
 
     FILE_BLACKLIST = [

--- a/lib/senkyoshi/models/resource.rb
+++ b/lib/senkyoshi/models/resource.rb
@@ -23,10 +23,8 @@ module Senkyoshi
         if original_src
           xid = original_src.split("/").last
           file_resource = resources.detect_xid(xid)
-
           if file_resource
-            path = file_resource.path
-            element[attr] = "#{BASE}/#{IMPORTED_FILES_DIRNAME}/#{path}"
+            element[attr] = "#{BASE}/#{file_resource.path}"
           end
         end
       end

--- a/lib/senkyoshi/models/resource.rb
+++ b/lib/senkyoshi/models/resource.rb
@@ -25,8 +25,8 @@ module Senkyoshi
           file_resource = resources.detect_xid(xid)
 
           if file_resource
-            name = file_resource.name
-            element[attr] = "#{BASE}/#{IMPORTED_FILES_DIRNAME}/#{name}"
+            path = file_resource.path
+            element[attr] = "#{BASE}/#{IMPORTED_FILES_DIRNAME}/#{path}"
           end
         end
       end

--- a/lib/senkyoshi/models/staff_info.rb
+++ b/lib/senkyoshi/models/staff_info.rb
@@ -77,13 +77,13 @@ module Senkyoshi
       @body << "</ul></div>"
     end
 
-    def canvas_conversion(course, _resources = nil)
+    def canvas_conversion(course, resources)
       # We want to create only a single "Contact" page, so once we already have
       # a StaffInfo resource, we won't want another one
       return course if @@page_created
 
       page = CanvasCc::CanvasCC::Models::Page.new
-      page.body = @@entries.join(" ")
+      page.body = fix_html(@@entries.join(" "), resources)
       page.identifier = @id
       page.page_name = @title.empty? ? "Contact" : @title
       @@page_created = true

--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -161,11 +161,14 @@ module Senkyoshi
   def self.iterate_files(zipfile)
     files = zipfile.entries.select(&:file?)
 
+    dir_names = zipfile.entries.map { |entry| File.dirname(entry.name) }.uniq
     file_names = files.map(&:name)
+    entry_names = dir_names + file_names
+
     scorm_paths = ScormPackage.find_scorm_paths(zipfile)
 
     files.select do |file|
-      SenkyoshiFile.valid_file?(file_names, scorm_paths, file)
+      SenkyoshiFile.valid_file?(entry_names, scorm_paths, file)
     end.
       map { |file| SenkyoshiFile.new(file) }
   end

--- a/spec/models/content_file_spec.rb
+++ b/spec/models/content_file_spec.rb
@@ -22,7 +22,7 @@ describe "ContentFile" do
     mock_entry = MockZip::MockEntry.new("ADV &amp;amp; DisAdv.pdf")
     assert_includes(
       file.canvas_conversion(mock_entry),
-      "href=\"$IMS_CC_FILEBASE$/#{IMPORTED_FILES_DIRNAME}/ADV",
+      "href=\"$IMS_CC_FILEBASE$/ADV",
     )
     assert_includes(
       file.canvas_conversion(mock_entry),

--- a/spec/models/file_spec.rb
+++ b/spec/models/file_spec.rb
@@ -47,16 +47,21 @@ describe "SenkyoshiFile" do
     mock_entries = [
       MockZip::MockEntry.new("csfiles/home_dir/test__xid-12.xml"),
       MockZip::MockEntry.new("csfiles/home_dir/test__xid-12.xml.xml"),
-      MockZip::MockEntry.new("csfiles/home_dir/test__xid-12.jpg"),
-      MockZip::MockEntry.new("csfiles/home_dir/test__xid-12.jpg.xml"),
+      MockZip::MockEntry.new("csfiles/home_dir/test__xid-23.jpg"),
+      MockZip::MockEntry.new("csfiles/home_dir/test__xid-23.jpg.xml"),
+      MockZip::MockEntry.new("csfiles/home_dir/test__xid-34"),
+      MockZip::MockEntry.new("csfiles/home_dir/test__xid-34.xml"),
     ]
 
-    file_names = mock_entries.map(&:name).sort
+    file_names = mock_entries.map(&:name)
+    dir_names = mock_entries.map { |entry| File.dirname(entry.name) }
+    entry_names = dir_names + file_names
+
     result = mock_entries.map do |entry|
-      SenkyoshiFile.metadata_file?(file_names, entry)
+      SenkyoshiFile.metadata_file?(entry_names, entry)
     end
 
-    expected_result = [false, true, false, true]
+    expected_result = [false, true, false, true, false, true]
 
     assert_equal(expected_result, result)
   end

--- a/spec/models/file_spec.rb
+++ b/spec/models/file_spec.rb
@@ -14,7 +14,7 @@ describe "SenkyoshiFile" do
 
   it "should iterate_xml" do
     assert_equal(@file.xid, "xid-1234_1")
-    assert_equal(@file.name, "file.txt")
+    assert_equal(@file.path, "fake/path/to/file.txt")
     assert_includes(@file.location, @path)
   end
 

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -43,15 +43,15 @@ describe Senkyoshi do
 
         results = @resource.fix_html(@contents, @resources)
 
-        assert_includes(results, "%24IMS-CC-FILEBASE%24/Imported/image123.jpg")
+        assert_includes(results, "%24IMS-CC-FILEBASE%24/fake/path/to/image123.jpg")
       end
 
       it "works correctly with multiple image tags" do
         @resources.add([@file1, @file2])
 
         results = @resource.fix_html(@contents, @resources)
-        correct_result_one = "%24IMS-CC-FILEBASE%24/Imported/image123.jpg"
-        correct_result_two = "%24IMS-CC-FILEBASE%24/Imported/image456.jpg"
+        correct_result_one = "%24IMS-CC-FILEBASE%24/fake/path/to/image123.jpg"
+        correct_result_two = "%24IMS-CC-FILEBASE%24/fake/path/to/image456.jpg"
 
         assert_includes(results, correct_result_one)
         assert_includes(results, correct_result_two)
@@ -76,8 +76,8 @@ describe Senkyoshi do
 
         results = @resource.fix_html(@contents, @resources)
 
-        href = "%24IMS-CC-FILEBASE%24/#{IMPORTED_FILES_DIRNAME}/pdf789.pdf"
-        src = "%24IMS-CC-FILEBASE%24/#{IMPORTED_FILES_DIRNAME}/image987.jpg"
+        href = "%24IMS-CC-FILEBASE%24/fake/path/to/pdf789.pdf"
+        src = "%24IMS-CC-FILEBASE%24/fake/path/to/image987.jpg"
 
         assert_includes(results, href)
         assert_includes(results, src)

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -43,7 +43,8 @@ describe Senkyoshi do
 
         results = @resource.fix_html(@contents, @resources)
 
-        assert_includes(results, "%24IMS-CC-FILEBASE%24/fake/path/to/image123.jpg")
+        expected_results = "%24IMS-CC-FILEBASE%24/fake/path/to/image123.jpg"
+        assert_includes(results, expected_results)
       end
 
       it "works correctly with multiple image tags" do

--- a/spec/models/staff_info_spec.rb
+++ b/spec/models/staff_info_spec.rb
@@ -8,6 +8,8 @@ require_relative "../../lib/senkyoshi/models/staff_info"
 describe "StaffInfo" do
   def setup
     StaffInfo.reset_entries
+
+    @resources = Senkyoshi::Collection.new
   end
 
   it "should parse xml" do
@@ -33,7 +35,7 @@ describe "StaffInfo" do
       StaffInfo.new.iterate_xml(get_fixture_xml("staff_info_1.xml"), nil),
       StaffInfo.new.iterate_xml(get_fixture_xml("staff_info_2.xml"), nil),
     ]
-    results.each { |staff| staff.canvas_conversion course }
+    results.each { |staff| staff.canvas_conversion course, @resources }
 
     assert_equal(course.pages.size, 1)
     assert_equal(course.pages.first.body.include?("Mr. Test Name"), true)


### PR DESCRIPTION
This changes Senkyoshi so it keeps the same file structure for course files as the Blackboard export instead of flattening everything into one directory.