### PR TITLE
Fix import quiz consistency. [#136593521]

### DIFF
--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -173,8 +173,13 @@ module Senkyoshi
       map { |file| SenkyoshiFile.new(file) }
   end
 
+  ##
+  # Create a random hex prepended with aj_
+  # This is because the instructure qti migration tool requires
+  # the first character to be a letter.
+  ##
   def self.create_random_hex
-    SecureRandom.hex
+    "aj_" + SecureRandom.hex(32)
   end
 
   def self.get_attribute_value(xml_data, type)

--- a/spec/xml_parser_spec.rb
+++ b/spec/xml_parser_spec.rb
@@ -65,7 +65,7 @@ describe Senkyoshi do
 
   describe "create_random_hex" do
     it "should return a random string" do
-      assert_equal Senkyoshi.create_random_hex.length, 32
+      assert_equal Senkyoshi.create_random_hex.length, 67
     end
   end
 


### PR DESCRIPTION
The instructure qti migration tool only accepts letters as the first character in identifiers.
This still uses SecureRandom.hex and prepends with a letter.

Previously the import would sometimes break when it found a number in the first place of an identifier. Thus leaving out the description and a couple other things.

It would break as it added `ID_` in front of the identifier, and then it couldn't find the meta file properly. So all the configs in the meta file wouldn't be applied to the assessment.

ie: `"migration_id"=>"ID_00e6c8165c9071d95a5b1cd769081889"}`
https://github.com/instructure/QTIMigrationTool/blob/d54544500558b0da72a6e9bc54c743467dcc2776/lib/imscp.py#L169
https://github.com/instructure/QTIMigrationTool/blob/d54544500558b0da72a6e9bc54c743467dcc2776/lib/xmlutils.py#L34