### PR TITLE
Fix survey to be converted as a graded_survey

### DIFF
--- a/lib/senkyoshi/models/assessment.rb
+++ b/lib/senkyoshi/models/assessment.rb
@@ -5,7 +5,7 @@ require "senkyoshi/models/resource"
 
 ASSESSMENT_TYPE = {
   "Test" => "assignment",
-  "Survey" => "survey",
+  "Survey" => "graded_survey",
 }.freeze
 
 module Senkyoshi


### PR DESCRIPTION
This makes it show up in the assignments.
If it is set to `survey`, that translates to an "Ungraded Survey"
in Canvas, and thus doesn’t show up in the assignments.