### PR TITLE
Fix generating contact pages

### DIFF
--- a/lib/senkyoshi/models/staff_info.rb
+++ b/lib/senkyoshi/models/staff_info.rb
@@ -1,4 +1,5 @@
 require "senkyoshi/models/resource"
+require "active_support/core_ext/string"
 
 module Senkyoshi
   class StaffInfo < Resource
@@ -58,6 +59,10 @@ module Senkyoshi
       body << str if var && !var.empty?
     end
 
+    def humanize(symbol)
+      symbol.to_s.humanize.titleize
+    end
+
     def construct_body(opts)
       body = "<div>"
       append_str body, "<img src=#{opts[:image]}/>", opts[:image]
@@ -65,23 +70,9 @@ module Senkyoshi
       append_str body, "<p>#{opts[:bio]}</p>", opts[:bio]
 
       body << "<ul>"
-      append_str body, "<li>Email: #{opts[:email]}</li>", opts[:email]
-      append_str body, "<li>Phone: #{opts[:phone]}</li>", opts[:phone]
-      append_str(
-        body,
-        "<li>Office Hours: #{opts[:office_hours]}</li>",
-        opts[:office_hours],
-      )
-      append_str(
-        body,
-        "<li>Office Address: #{opts[:office_address]}</li>",
-        opts[:office_address],
-      )
-      append_str(
-        body,
-        "<li>Home Page: #{opts[:home_page]}</li>",
-        opts[:home_page],
-      )
+      [:email, :phone, :office_hours, :office_address, :home_page].each do |key|
+        append_str body, "<li>#{humanize(key)}: #{opts[key]}</li>", opts[key]
+      end
       body << "</ul></div>"
       body
     end

--- a/lib/senkyoshi/models/staff_info.rb
+++ b/lib/senkyoshi/models/staff_info.rb
@@ -5,24 +5,11 @@ module Senkyoshi
     attr_reader(
       :id,
       :title,
-      :bio,
-      :name,
-      :email,
-      :phone,
-      :office_hours,
-      :office_address,
-      :home_page,
-      :image,
+      :entries,
     )
 
-    def self.reset_entries
-      @@entries = []
-      @@page_created = false
-    end
-
     def initialize
-      @@entries ||= []
-      @@page_created = false
+      @entries = []
     end
 
     def parse_name(contact)
@@ -42,51 +29,68 @@ module Senkyoshi
 
     def iterate_xml(xml, _pre_data)
       contact = xml.xpath("//CONTACT")
-      @id = xml.xpath("//STAFFINFO/@id").text
-      @title = xml.xpath("//STAFFINFO/TITLE/@value").text
-      @bio = xml.xpath("//BIOGRAPHY/TEXT").text
-      @name = parse_name(contact)
-      @email = xml.xpath("//CONTACT/EMAIL/@value").text
-      @phone = xml.xpath("//CONTACT/PHONE/@value").text
-      @office_hours = xml.xpath("//OFFICE/HOURS/@value").text
-      @office_address = xml.xpath("//OFFICE/ADDRESS/@value").text
-      @home_page = xml.xpath("//HOMEPAGE/@value").text
-      @image = xml.xpath("//IMAGE/@value").text
+      @id ||= xml.xpath("//STAFFINFO/@id").text || Senkyoshi.create_random_hex
+      @title ||= xml.xpath("//STAFFINFO/TITLE/@value").text
+      bio = xml.xpath("//BIOGRAPHY/TEXT").text
+      name = parse_name(contact)
+      email = xml.xpath("//CONTACT/EMAIL/@value").text
+      phone = xml.xpath("//CONTACT/PHONE/@value").text
+      office_hours = xml.xpath("//OFFICE/HOURS/@value").text
+      office_address = xml.xpath("//OFFICE/ADDRESS/@value").text
+      home_page = xml.xpath("//HOMEPAGE/@value").text
+      image = xml.xpath("//IMAGE/@value").text
 
-      @@entries << construct_body
+      @entries << construct_body(
+        bio: bio,
+        name: name,
+        email: email,
+        phone: phone,
+        office_hours: office_hours,
+        office_address: office_address,
+        home_page: home_page,
+        image: image,
+      )
 
       self
     end
 
-    def add_to_body(str, var)
-      @body << str if var && !var.empty?
+    def append_str(body, str, var)
+      body << str if var && !var.empty?
     end
 
-    def construct_body
-      @body = "<div>"
-      add_to_body "<img src=#{@image}/>", @image
-      add_to_body "<h3>#{@name}</h3>", @name
-      add_to_body "<p>#{@bio}</p>", @bio
+    def construct_body(opts)
+      body = "<div>"
+      append_str body, "<img src=#{opts[:image]}/>", opts[:image]
+      append_str body, "<h3>#{opts[:name]}</h3>", opts[:name]
+      append_str body, "<p>#{opts[:bio]}</p>", opts[:bio]
 
-      @body << "<ul>"
-      add_to_body "<li>Email: #{@email}</li>", @email
-      add_to_body "<li>Phone: #{@phone}</li>", @phone
-      add_to_body "<li>Office Hours: #{@office_hours}</li>", @office_hours
-      add_to_body "<li>Office Address: #{@office_address}</li>", @office_address
-      add_to_body "<li>Home Page: #{@home_page}</li>", @home_page
-      @body << "</ul></div>"
+      body << "<ul>"
+      append_str body, "<li>Email: #{opts[:email]}</li>", opts[:email]
+      append_str body, "<li>Phone: #{opts[:phone]}</li>", opts[:phone]
+      append_str(
+        body,
+        "<li>Office Hours: #{opts[:office_hours]}</li>",
+        opts[:office_hours],
+      )
+      append_str(
+        body,
+        "<li>Office Address: #{opts[:office_address]}</li>",
+        opts[:office_address],
+      )
+      append_str(
+        body,
+        "<li>Home Page: #{opts[:home_page]}</li>",
+        opts[:home_page],
+      )
+      body << "</ul></div>"
+      body
     end
 
     def canvas_conversion(course, resources)
-      # We want to create only a single "Contact" page, so once we already have
-      # a StaffInfo resource, we won't want another one
-      return course if @@page_created
-
       page = CanvasCc::CanvasCC::Models::Page.new
-      page.body = fix_html(@@entries.join(" "), resources)
+      page.body = fix_html(@entries.join(" "), resources)
       page.identifier = @id
       page.page_name = @title.empty? ? "Contact" : @title
-      @@page_created = true
 
       course.pages << page
       course

--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -73,6 +73,7 @@ module Senkyoshi
 
   def self.iterate_xml(organizations, resources, zip_file, resource_xids)
     pre_data = pre_iterator(organizations, resources, zip_file)
+    staff_info = StaffInfo.new
     iterator_master(resources, zip_file) do |xml_data, type, file|
       if RESOURCE_TYPE[type.to_sym]
         single_pre_data = get_single_pre_data(pre_data, file)
@@ -83,6 +84,8 @@ module Senkyoshi
         when "questestinterop"
           single_pre_data ||= { file_name: file }
           QTI.from(xml_data, single_pre_data)
+        when "staffinfo"
+          staff_info.iterate_xml(xml_data, single_pre_data)
         else
           resource = res_class.new
           resource.iterate_xml(xml_data, single_pre_data)

--- a/spec/models/staff_info_spec.rb
+++ b/spec/models/staff_info_spec.rb
@@ -7,35 +7,38 @@ require_relative "../../lib/senkyoshi/models/staff_info"
 
 describe "StaffInfo" do
   def setup
-    StaffInfo.reset_entries
-
     @resources = Senkyoshi::Collection.new
   end
 
   it "should parse xml" do
     xml = get_fixture_xml("staff_info_1.xml")
+    bio = "Contact this office for asistance."
+    name = "Mr. Test Name"
+    office_hours = "24/7"
+    office_address = "123 Fake St."
+    home_page = "example.com"
+    image = "example.com/image.png"
+
     staff_info = StaffInfo.new.iterate_xml(xml, nil)
 
     assert_equal(staff_info.id, "_112170_1")
     assert_equal(staff_info.title, "Test Title")
-    assert_equal(
-      staff_info.bio.include?("Contact this office for asistance."),
-      true,
-    )
-    assert_equal(staff_info.name, "Mr. Test Name")
-    assert_equal(staff_info.office_hours, "24/7")
-    assert_equal(staff_info.office_address, "123 Fake St.")
-    assert_equal(staff_info.home_page, "example.com")
-    assert_equal(staff_info.image, "example.com/image.png")
+
+    assert_includes(staff_info.entries.first, bio)
+    assert_includes(staff_info.entries.first, name)
+    assert_includes(staff_info.entries.first, office_hours)
+    assert_includes(staff_info.entries.first, office_address)
+    assert_includes(staff_info.entries.first, home_page)
+    assert_includes(staff_info.entries.first, image)
   end
 
   it "should convert to a single canvas page" do
     course = CanvasCc::CanvasCC::Models::Course.new
-    results = [
-      StaffInfo.new.iterate_xml(get_fixture_xml("staff_info_1.xml"), nil),
-      StaffInfo.new.iterate_xml(get_fixture_xml("staff_info_2.xml"), nil),
-    ]
-    results.each { |staff| staff.canvas_conversion course, @resources }
+
+    staff_info = StaffInfo.new
+    staff_info.iterate_xml(get_fixture_xml("staff_info_1.xml"), nil)
+    staff_info.iterate_xml(get_fixture_xml("staff_info_2.xml"), nil)
+    staff_info.canvas_conversion course, @resources
 
     assert_equal(course.pages.size, 1)
     assert_equal(course.pages.first.body.include?("Mr. Test Name"), true)


### PR DESCRIPTION
Remove class variables.
Use only one instance of StaffInfo.

This fixes the contact page to contain contact info for only the given course. Also fixes so it works with `-m` in the task.