### PR TITLE
 Update Assignment Groups 

### DIFF
--- a/lib/senkyoshi/models/assignment_group.rb
+++ b/lib/senkyoshi/models/assignment_group.rb
@@ -25,9 +25,13 @@ module Senkyoshi
       group.canvas_conversion
     end
 
-    def self.find_or_create(course, category)
-      assignment_group = course.assignment_groups.
+    def self.find_group(course, category)
+      course.assignment_groups.
         detect { |a| a.title == category }
+    end
+
+    def self.find_or_create(course, category)
+      assignment_group = find_group(course, category)
       unless assignment_group
         assignment_group = AssignmentGroup.create_assignment_group(category)
         course.assignment_groups << assignment_group

--- a/lib/senkyoshi/models/assignment_group.rb
+++ b/lib/senkyoshi/models/assignment_group.rb
@@ -32,7 +32,7 @@ module Senkyoshi
 
     def self.find_or_create(course, category)
       assignment_group = find_group(course, category)
-      unless assignment_group
+      if !assignment_group
         assignment_group = AssignmentGroup.create_assignment_group(category)
         course.assignment_groups << assignment_group
       end

--- a/lib/senkyoshi/models/assignment_group.rb
+++ b/lib/senkyoshi/models/assignment_group.rb
@@ -3,21 +3,26 @@ require "senkyoshi/models/resource"
 module Senkyoshi
   class AssignmentGroup < Resource
     attr_reader :id
-    def initialize(name, group_id)
+    def initialize(name, id)
       @title = name
       @group_weight = ""
       @rules = {}
-      @id = group_id
+      @id = id
     end
 
-    def canvas_conversion(course, _resources = nil)
+    def canvas_conversion
       assignment_group = CanvasCc::CanvasCC::Models::AssignmentGroup.new
       assignment_group.identifier = @id
       assignment_group.title = @title
       assignment_group.group_weight = @group_weight
       assignment_group.rules = @rules
-      course.assignment_groups << assignment_group
-      course
+      assignment_group
+    end
+
+    def self.create_assignment_group(group_name)
+      id = Senkyoshi.create_random_hex
+      group = AssignmentGroup.new(group_name, id)
+      group.canvas_conversion
     end
   end
 end

--- a/lib/senkyoshi/models/assignment_group.rb
+++ b/lib/senkyoshi/models/assignment_group.rb
@@ -24,5 +24,15 @@ module Senkyoshi
       group = AssignmentGroup.new(group_name, id)
       group.canvas_conversion
     end
+
+    def self.find_or_create(course, category)
+      assignment_group = course.assignment_groups.
+        detect { |a| a.title == category }
+      unless assignment_group
+        assignment_group = AssignmentGroup.create_assignment_group(category)
+        course.assignment_groups << assignment_group
+      end
+      assignment_group
+    end
   end
 end

--- a/lib/senkyoshi/models/content.rb
+++ b/lib/senkyoshi/models/content.rb
@@ -80,7 +80,7 @@ module Senkyoshi
       module_item.canvas_conversion
     end
 
-    def get_pre_data(xml, file_name)
+    def self.get_pre_data(xml, file_name)
       id = xml.xpath("/CONTENT/@id").first.text
       parent_id = xml.xpath("/CONTENT/PARENTID/@value").first.text
       {

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -43,7 +43,7 @@ module Senkyoshi
       xml.xpath("//OUTCOMEDEFINITION").map do |outcome_definition|
         category_id = outcome_definition.xpath("CATEGORYID/@value").first.value
         category = @categories[category_id]
-        OutcomeDefinition.from_xml(outcome_definition, category)
+        OutcomeDefinition.from(outcome_definition, category)
       end
     end
 

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -1,11 +1,14 @@
 require "byebug"
 require "senkyoshi/models/outcome_definition"
+require "senkyoshi/models/resource"
+
 module Senkyoshi
-  class Gradebook
+  class Gradebook < Resource
     attr_accessor(:outcome_definitions)
 
     def iterate_xml(xml_data, _)
-      @outcome_definitions = Gradebook.get_outcome_definitions(xml_data)
+      @categories = Gradebook.get_categories(xml_data)
+      @outcome_definitions = get_outcome_definitions(xml_data)
       self
     end
 
@@ -36,9 +39,12 @@ module Senkyoshi
       end
     end
 
-    def self.get_outcome_definitions(xml)
-      xml.xpath("//OUTCOMEDEFINITION").
-        map { |out| OutcomeDefinition.from_xml(out) }
+    def get_outcome_definitions(xml)
+      xml.xpath("//OUTCOMEDEFINITION").map do |outcome_definition|
+        category_id = outcome_definition.xpath("CATEGORYID/@value").first.value
+        category = @categories[category_id]
+        OutcomeDefinition.from_xml(outcome_definition, category)
+      end
     end
 
     def canvas_conversion(course, _ = nil)

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -8,7 +8,7 @@ module Senkyoshi
 
     def iterate_xml(xml_data, _)
       @categories = Gradebook.get_categories(xml_data)
-      @outcome_definitions = get_outcome_definitions(xml_data)
+      @outcome_definitions = get_outcome_definitions(xml_data).compact
       self
     end
 
@@ -41,9 +41,12 @@ module Senkyoshi
 
     def get_outcome_definitions(xml)
       xml.xpath("//OUTCOMEDEFINITION").map do |outcome_definition|
-        category_id = outcome_definition.xpath("CATEGORYID/@value").first.value
-        category = @categories[category_id]
-        OutcomeDefinition.from(outcome_definition, category)
+        user_created = outcome_definition.xpath("ISUSERCREATED/@value").first.value
+        if user_created == "true"
+          category_id = outcome_definition.xpath("CATEGORYID/@value").first.value
+          category = @categories[category_id]
+          OutcomeDefinition.from(outcome_definition, category)
+        end
       end
     end
 

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -6,6 +6,11 @@ module Senkyoshi
   class Gradebook < Resource
     attr_accessor(:outcome_definitions, :categories)
 
+    def initialize
+      @categories = []
+      @outcome_definitions = []
+    end
+
     def iterate_xml(xml_data, _)
       @categories = Gradebook.get_categories(xml_data)
       @outcome_definitions = get_outcome_definitions(xml_data).compact
@@ -45,8 +50,10 @@ module Senkyoshi
 
     def convert_categories(course)
       @categories.each do |category|
-        course.assignment_groups <<
-          AssignmentGroup.create_assignment_group(category.last)
+        if AssignmentGroup.find_group(course, category.last).nil?
+          course.assignment_groups <<
+            AssignmentGroup.create_assignment_group(category.last)
+        end
       end
     end
 

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -1,6 +1,15 @@
+require "byebug"
 module Senkyoshi
   class Gradebook
-    def get_pre_data(data, _)
+
+    def initialize
+    end
+
+    def iterate_xml(xml_data, single_pre_data)
+      byebug
+    end
+
+    def self.get_pre_data(data, _)
       categories = get_categories(data)
       data.search("OUTCOMEDEFINITIONS").children.map do |outcome|
         content_id = outcome.at("CONTENTID").attributes["value"].value
@@ -17,7 +26,7 @@ module Senkyoshi
       end
     end
 
-    def get_categories(data)
+    def self.get_categories(data)
       data.at("CATEGORIES").children.
         each_with_object({}) do |category, categories|
         id = category.attributes["id"].value

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -4,7 +4,7 @@ require "senkyoshi/models/resource"
 
 module Senkyoshi
   class Gradebook < Resource
-    attr_accessor(:outcome_definitions)
+    attr_accessor(:outcome_definitions, :categories)
 
     def iterate_xml(xml_data, _)
       @categories = Gradebook.get_categories(xml_data)

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -1,14 +1,13 @@
-require "byebug"
 require "senkyoshi/models/outcome_definition"
 require "senkyoshi/models/resource"
 
 module Senkyoshi
   class Gradebook < Resource
-    attr_accessor(:outcome_definitions, :categories)
+    attr_reader(:outcome_definitions, :categories)
 
-    def initialize
-      @categories = []
-      @outcome_definitions = []
+    def initialize(categories = [], outcome_definitions = [])
+      @categories = categories
+      @outcome_definitions = outcome_definitions
     end
 
     def iterate_xml(xml_data, _)

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -1,12 +1,12 @@
 require "byebug"
+require "senkyoshi/models/outcome_definition"
 module Senkyoshi
   class Gradebook
+    attr_accessor(:outcome_definitions)
 
-    def initialize
-    end
-
-    def iterate_xml(xml_data, single_pre_data)
-      byebug
+    def iterate_xml(xml_data, _)
+      @outcome_definitions = Gradebook.get_outcome_definitions(xml_data)
+      self
     end
 
     def self.get_pre_data(data, _)
@@ -34,6 +34,19 @@ module Senkyoshi
           attributes["value"].value.gsub(".name", "")
         categories[id] = title
       end
+    end
+
+    def self.get_outcome_definitions(xml)
+      xml.xpath("//OUTCOMEDEFINITION").
+        map { |out| OutcomeDefinition.from_xml(out) }
+    end
+
+    def canvas_conversion(course, _ = nil)
+      # Convert all outcome definitions to assignments
+      @outcome_definitions.
+        select { |outcome_def| outcome_def.content_id.empty? }.
+        each { |outcome_def| outcome_def.canvas_conversion course, _ }
+      course
     end
   end
 end

--- a/lib/senkyoshi/models/gradebook.rb
+++ b/lib/senkyoshi/models/gradebook.rb
@@ -56,11 +56,11 @@ module Senkyoshi
       end
     end
 
-    def canvas_conversion(course, _ = nil)
+    def canvas_conversion(course, resources = nil)
       convert_categories(course)
       @outcome_definitions.
         select { |outcome_def| OutcomeDefinition.orphan? outcome_def }.
-        each { |outcome_def| outcome_def.canvas_conversion course, _ }
+        each { |outcome_def| outcome_def.canvas_conversion course, resources }
       course
     end
   end

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -4,7 +4,7 @@ require "senkyoshi/models/assignment_group"
 require "byebug"
 module Senkyoshi
   class OutcomeDefinition < Resource
-    attr_reader :content_id, :asidataid, :is_user_created
+    attr_reader :id, :content_id, :asidataid, :is_user_created
     def self.from(xml, category)
       outcome_definition = OutcomeDefinition.new(category)
       outcome_definition.iterate_xml(xml)

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -1,20 +1,27 @@
 require "byebug"
 module Senkyoshi
   class OutcomeDefinition
-    def initialize(id, content_id)
+    attr_reader(:id, :content_id, :title, :points_possible)
+
+    def initialize(id, content_id, title, points_possible)
       @id = id
       @content_id = content_id
+      @title = title
+      @points_possible = points_possible
     end
 
     def canvas_conversion(course, _)
       # Create an assignment
+      assignment = CanvasCc::CanvasCC::Models::Assignment.new
+
+      course.assignments << assignment
       course
     end
 
     def self.from_xml(xml)
       content_id = xml.xpath("./CONTENTID/@value").text
       id = xml.xpath("./@id").text
-      OutcomeDefinition.new(id, content_id)
+      OutcomeDefinition.new(id, content_id, nil, nil)
     end
   end
 end

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -4,7 +4,7 @@ require "senkyoshi/models/assignment_group"
 require "byebug"
 module Senkyoshi
   class OutcomeDefinition < Resource
-    attr_reader :content_id, :asidataid
+    attr_reader :content_id, :asidataid, :is_user_created
     def self.from(xml, category)
       outcome_definition = OutcomeDefinition.new(category)
       outcome_definition.iterate_xml(xml)
@@ -20,6 +20,7 @@ module Senkyoshi
       @id = xml.xpath("./@id").text
       @title = xml.xpath("./TITLE/@value").text
       @points_possible = xml.xpath("./POINTSPOSSIBLE/@value").text
+      @is_user_created = xml.xpath("./ISUSERCREATED/@value").text == "true"
       self
     end
 
@@ -28,11 +29,12 @@ module Senkyoshi
     # assignments
     ##
     def self.orphan?(outcome_def)
-      outcome_def.content_id.empty? && outcome_def.asidataid.empty?
+      outcome_def.content_id.empty? &&
+        outcome_def.asidataid.empty? &&
+        outcome_def.is_user_created
     end
 
     def canvas_conversion(course, _)
-
       assignment_group = course.assignment_groups.
         detect { |a| a.title == @category }
       unless assignment_group

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -1,0 +1,24 @@
+require "byebug"
+module Senkyoshi
+  class OutcomeDefinition
+    def initialize(id, content_id)
+      @id = id
+      @content_id = content_id
+    end
+
+    def canvas_conversion(course, _)
+      # Create an assignment
+      course
+    end
+
+    def self.from_xml(xml)
+      content_id = xml.xpath("./CONTENTID/@value").text
+      id = xml.xpath("./@id").text
+      OutcomeDefinition.new(id, content_id)
+    end
+
+    def self.should_create_assignment?(xml)
+      xml.xpath("./OUTCOMEDEFINITION/CONTENTID/@value").first.text
+    end
+  end
+end

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -35,12 +35,7 @@ module Senkyoshi
     end
 
     def canvas_conversion(course, _)
-      assignment_group = course.assignment_groups.
-        detect { |a| a.title == @category }
-      unless assignment_group
-        assignment_group = AssignmentGroup.create_assignment_group(@category)
-        course.assignment_groups << assignment_group
-      end
+      assignment_group = AssignmentGroup.find_or_create(course, @category)
 
       # Create an assignment
       assignment = CanvasCc::CanvasCC::Models::Assignment.new

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -10,8 +10,6 @@ module Senkyoshi
 
     def initialize(category)
       @category = category
-      @points_possible = 0
-      @workflow_state = "published"
     end
 
     def iterate_xml(xml)
@@ -29,11 +27,10 @@ module Senkyoshi
       assignment = CanvasCc::CanvasCC::Models::Assignment.new
       assignment.identifier = Senkyoshi.create_random_hex
       assignment.assignment_group_identifier_ref = @group_id
-      # assignment.submission_types << "online_quiz"
       assignment.title = @title
       assignment.position = 1
       assignment.points_possible = @points_possible
-      assignment.workflow_state = @workflow_state
+      assignment.workflow_state = "published"
       assignment.grading_type = "points"
 
       course.assignments << assignment

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -3,6 +3,7 @@ require "senkyoshi/models/assignment_group"
 
 module Senkyoshi
   class OutcomeDefinition < Resource
+    include Senkyoshi
     attr_reader :id, :content_id, :asidataid, :is_user_created
     def self.from(xml, category)
       outcome_definition = OutcomeDefinition.new(category)
@@ -19,7 +20,7 @@ module Senkyoshi
       @id = xml.xpath("./@id").text
       @title = xml.xpath("./TITLE/@value").text
       @points_possible = xml.xpath("./POINTSPOSSIBLE/@value").text
-      @is_user_created = xml.xpath("./ISUSERCREATED/@value").text == "true"
+      @is_user_created = true? xml.xpath("./ISUSERCREATED/@value").text
       self
     end
 

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -1,27 +1,55 @@
 require "byebug"
 module Senkyoshi
   class OutcomeDefinition
-    attr_reader(:id, :content_id, :title, :points_possible)
+    attr_reader :content_id
 
-    def initialize(id, content_id, title, points_possible)
-      @id = id
-      @content_id = content_id
-      @title = title
-      @points_possible = points_possible
+    def initialize(category)
+      @category = category
+      @points_possible = 0
+      @workflow_state = "published"
+    end
+
+    def iterate_xml(xml)
+      @content_id = xml.xpath("./CONTENTID/@value").text
+      @id = xml.xpath("./@id").text
+      @title = xml.xpath("./TITLE/@value").text
+      @points_possible = xml.xpath("./POINTSPOSSIBLE/@value").text
+      self
     end
 
     def canvas_conversion(course, _)
+      course = create_assignment_group(course)
+
       # Create an assignment
       assignment = CanvasCc::CanvasCC::Models::Assignment.new
+      assignment.identifier = Senkyoshi.create_random_hex
+      assignment.assignment_group_identifier_ref = @group_id
+      # assignment.submission_types << "online_quiz"
+      assignment.title = @title
+      assignment.position = 1
+      assignment.points_possible = @points_possible
+      assignment.workflow_state = @workflow_state
+      assignment.grading_type = "points"
 
       course.assignments << assignment
       course
     end
 
-    def self.from_xml(xml)
-      content_id = xml.xpath("./CONTENTID/@value").text
-      id = xml.xpath("./@id").text
-      OutcomeDefinition.new(id, content_id, nil, nil)
+    def create_assignment_group(course)
+      group = course.assignment_groups.detect { |a| a.title == @group_name }
+      if group
+        @group_id = group.identifier
+      else
+        @group_id = Senkyoshi.create_random_hex
+        assignment_group = AssignmentGroup.new(@group_name, @group_id)
+        course = assignment_group.canvas_conversion(course, nil)
+      end
+      course
+    end
+
+    def self.from_xml(xml, category)
+      outcome_definition = OutcomeDefinition.new(category)
+      outcome_definition.iterate_xml(xml)
     end
   end
 end

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -1,7 +1,6 @@
 require "senkyoshi/models/resource"
 require "senkyoshi/models/assignment_group"
 
-require "byebug"
 module Senkyoshi
   class OutcomeDefinition < Resource
     attr_reader :id, :content_id, :asidataid, :is_user_created
@@ -25,8 +24,8 @@ module Senkyoshi
     end
 
     ##
-    # Determine if an outcome definition is linked to any 'CONTENT' or
-    # assignments
+    # Determine if an outcome definition is user created and linked to any
+    # other 'CONTENT' or assignments
     ##
     def self.orphan?(outcome_def)
       outcome_def.content_id.empty? &&
@@ -36,7 +35,6 @@ module Senkyoshi
 
     def canvas_conversion(course, _ = nil)
       assignment_group = AssignmentGroup.find_or_create(course, @category)
-      # Create an assignment
       assignment = CanvasCc::CanvasCC::Models::Assignment.new
       assignment.identifier = Senkyoshi.create_random_hex
       assignment.assignment_group_identifier_ref = assignment_group.identifier

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -16,9 +16,5 @@ module Senkyoshi
       id = xml.xpath("./@id").text
       OutcomeDefinition.new(id, content_id)
     end
-
-    def self.should_create_assignment?(xml)
-      xml.xpath("./OUTCOMEDEFINITION/CONTENTID/@value").first.text
-    end
   end
 end

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -34,9 +34,8 @@ module Senkyoshi
         outcome_def.is_user_created
     end
 
-    def canvas_conversion(course, _)
+    def canvas_conversion(course, _ = nil)
       assignment_group = AssignmentGroup.find_or_create(course, @category)
-
       # Create an assignment
       assignment = CanvasCc::CanvasCC::Models::Assignment.new
       assignment.identifier = Senkyoshi.create_random_hex

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -3,6 +3,11 @@ module Senkyoshi
   class OutcomeDefinition
     attr_reader :content_id
 
+    def self.from(xml, category)
+      outcome_definition = OutcomeDefinition.new(category)
+      outcome_definition.iterate_xml(xml)
+    end
+
     def initialize(category)
       @category = category
       @points_possible = 0
@@ -45,11 +50,6 @@ module Senkyoshi
         course = assignment_group.canvas_conversion(course, nil)
       end
       course
-    end
-
-    def self.from_xml(xml, category)
-      outcome_definition = OutcomeDefinition.new(category)
-      outcome_definition.iterate_xml(xml)
     end
   end
 end

--- a/lib/senkyoshi/models/outcome_definition.rb
+++ b/lib/senkyoshi/models/outcome_definition.rb
@@ -1,8 +1,10 @@
+require "senkyoshi/models/resource"
 require "senkyoshi/models/assignment_group"
 
+require "byebug"
 module Senkyoshi
-  class OutcomeDefinition
-    attr_reader :content_id
+  class OutcomeDefinition < Resource
+    attr_reader :content_id, :asidataid
     def self.from(xml, category)
       outcome_definition = OutcomeDefinition.new(category)
       outcome_definition.iterate_xml(xml)
@@ -14,13 +16,23 @@ module Senkyoshi
 
     def iterate_xml(xml)
       @content_id = xml.xpath("./CONTENTID/@value").text
+      @asidataid = xml.xpath("./ASIDATAID/@value").text
       @id = xml.xpath("./@id").text
       @title = xml.xpath("./TITLE/@value").text
       @points_possible = xml.xpath("./POINTSPOSSIBLE/@value").text
       self
     end
 
+    ##
+    # Determine if an outcome definition is linked to any 'CONTENT' or
+    # assignments
+    ##
+    def self.orphan?(outcome_def)
+      outcome_def.content_id.empty? && outcome_def.asidataid.empty?
+    end
+
     def canvas_conversion(course, _)
+
       assignment_group = course.assignment_groups.
         detect { |a| a.title == @category }
       unless assignment_group

--- a/lib/senkyoshi/models/qti.rb
+++ b/lib/senkyoshi/models/qti.rb
@@ -109,12 +109,7 @@ module Senkyoshi
     def canvas_conversion(course, resources)
       assessment = CanvasCc::CanvasCC::Models::Assessment.new
       assessment.identifier = @id
-      assignment_group = course.assignment_groups.
-        detect { |a| a.title == @group_name }
-      unless assignment_group
-        assignment_group = AssignmentGroup.create_assignment_group(@group_name)
-        course.assignment_groups << assignment_group
-      end
+      assignment_group = AssignmentGroup.find_or_create(course, @group_name)
       assignment = create_assignment(assignment_group.identifier)
       assignment.quiz_identifier_ref = assessment.identifier
       course.assignments << assignment

--- a/lib/senkyoshi/models/qti.rb
+++ b/lib/senkyoshi/models/qti.rb
@@ -85,7 +85,7 @@ module Senkyoshi
       end
     end
 
-    def get_pre_data(xml, _)
+    def self.get_pre_data(xml, _)
       {
         original_file_name: xml.xpath("/COURSEASSESSMENT/
           ASMTID/@value").first.text,

--- a/lib/senkyoshi/models/resource.rb
+++ b/lib/senkyoshi/models/resource.rb
@@ -31,5 +31,7 @@ module Senkyoshi
         end
       end
     end
+
+    def self.get_pre_data(_xml, _file_name); end
   end
 end

--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -52,6 +52,7 @@ module Senkyoshi
     questestinterop: "Assessment",
     content: "Content",
     staffinfo: "StaffInfo",
+    gradebook: "Gradebook",
   }.freeze
 
   PRE_RESOURCE_TYPE = {
@@ -107,9 +108,8 @@ module Senkyoshi
     iterator_master(resources, zip_file) do |xml_data, type, file|
       if PRE_RESOURCE_TYPE[type.to_sym]
         res_class = Senkyoshi.const_get PRE_RESOURCE_TYPE[type.to_sym]
-        resource_class = res_class.new
         pre_data[type] ||= []
-        pre_data[type].push(resource_class.get_pre_data(xml_data, file))
+        pre_data[type].push(res_class.get_pre_data(xml_data, file))
       end
     end
     pre_data = connect_content(pre_data)

--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -121,7 +121,8 @@ module Senkyoshi
       if PRE_RESOURCE_TYPE[type.to_sym]
         res_class = Senkyoshi.const_get PRE_RESOURCE_TYPE[type.to_sym]
         pre_data[type] ||= []
-        pre_data[type].push(res_class.get_pre_data(xml_data, file))
+        data = res_class.get_pre_data(xml_data, file)
+        pre_data[type].push(data) if data
       end
     end
     pre_data = connect_content(pre_data)

--- a/spec/fixtures/outcome_definition.xml
+++ b/spec/fixtures/outcome_definition.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OUTCOMEDEFINITION id="_3006852_1">
+  <CATEGORYID value="_2855033_1" />
+  <SCALEID value="_1631360_1" />
+  <SECONDARY_SCALEID value="" />
+  <CONTENTID value="res00021" />
+  <GRADING_PERIODID value="" />
+  <ASIDATAID value="res00014" />
+  <DATES>
+    <CREATED value="2016-12-01 15:17:10 EST" />
+    <UPDATED value="2016-12-01 15:17:10 EST" />
+    <DUE value="" />
+  </DATES>
+  <TITLE value="All the things" />
+  <DISPLAY_TITLE value="" />
+  <POSITION value="3" />
+  <VERSION value="549875116" />
+  <DELETED value="false" />
+  <EXTERNALREF value="" />
+  <HANDLERURL value="" />
+  <ANALYSISURL value="" />
+  <WEIGHT value="0" />
+  <POINTSPOSSIBLE value="50.0" />
+  <ISVISIBLE value="true" />
+  <VISIBLE_BOOK value="true" />
+  <VISIBLE_ALL_TERMS value="false" />
+  <SHOW_STATS_TO_STUDENT value="false" />
+  <HIDEATTEMPT value="false" />
+  <AGGREGATIONMODEL value="Last" />
+  <SCORE_PROVIDER_HANDLE value="resource/x-bb-assessment" />
+  <SINGLE_ATTEMPT value="false" />
+  <CALCULATIONTYPE value="NON_CALCULATED" />
+  <ISCALCULATED value="false" />
+  <ISSCORABLE value="true" />
+  <ISUSERCREATED value="false" />
+  <MULTIPLEATTEMPTS value="1" />
+  <ACTIVITY_COUNT_COL_DEFS />
+</OUTCOMEDEFINITION>

--- a/spec/fixtures/user_created_outcome_definition.xml
+++ b/spec/fixtures/user_created_outcome_definition.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OUTCOMEDEFINITION id="_3006852_1">
+  <CATEGORYID value="_2855033_1" />
+  <SCALEID value="_1631360_1" />
+  <SECONDARY_SCALEID value="" />
+  <CONTENTID value="" />
+  <GRADING_PERIODID value="" />
+  <ASIDATAID value="" />
+  <DATES>
+    <CREATED value="2016-12-01 15:17:10 EST" />
+    <UPDATED value="2016-12-01 15:17:10 EST" />
+    <DUE value="" />
+  </DATES>
+  <TITLE value="All the things" />
+  <DISPLAY_TITLE value="" />
+  <POSITION value="3" />
+  <VERSION value="549875116" />
+  <DELETED value="false" />
+  <EXTERNALREF value="" />
+  <HANDLERURL value="" />
+  <ANALYSISURL value="" />
+  <WEIGHT value="0" />
+  <POINTSPOSSIBLE value="50.0" />
+  <ISVISIBLE value="true" />
+  <VISIBLE_BOOK value="true" />
+  <VISIBLE_ALL_TERMS value="false" />
+  <SHOW_STATS_TO_STUDENT value="false" />
+  <HIDEATTEMPT value="false" />
+  <AGGREGATIONMODEL value="Last" />
+  <SCORE_PROVIDER_HANDLE value="resource/x-bb-assessment" />
+  <SINGLE_ATTEMPT value="false" />
+  <CALCULATIONTYPE value="NON_CALCULATED" />
+  <ISCALCULATED value="false" />
+  <ISSCORABLE value="true" />
+  <ISUSERCREATED value="true" />
+  <MULTIPLEATTEMPTS value="1" />
+  <ACTIVITY_COUNT_COL_DEFS />
+</OUTCOMEDEFINITION>

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -98,7 +98,7 @@ describe Senkyoshi do
         pre_data = {}
         @assessment = @assessment.iterate_xml(xml.children.first, pre_data)
 
-        result = AssignmentGroup.create_assignment_group("fake_group_name_123")
+        result = AssignmentGroup.create_assignment_group(@assignment_group_id)
         assert_equal result.class, CanvasCc::CanvasCC::Models::AssignmentGroup
       end
     end

--- a/spec/models/assessment_spec.rb
+++ b/spec/models/assessment_spec.rb
@@ -11,6 +11,7 @@ describe Senkyoshi do
     before do
       @assessment = Assessment.new
       @resources = Senkyoshi::Collection.new
+      @assignment_group_id = "fake_assn_id_123"
     end
 
     describe "initialize" do
@@ -69,7 +70,7 @@ describe Senkyoshi do
         description = "<p>Do this test with honor</p>"
         instructions = "<p>Don't forget your virtue</p>"
 
-        assignment = @assessment.create_assignment
+        assignment = @assessment.create_assignment(@assignment_group_id)
         assessment =
           @assessment.setup_assessment(assessment, assignment, @resources)
         assert_equal assessment.title, title
@@ -96,10 +97,9 @@ describe Senkyoshi do
         xml = get_fixture_xml "assessment.xml"
         pre_data = {}
         @assessment = @assessment.iterate_xml(xml.children.first, pre_data)
-        course = CanvasCc::CanvasCC::Models::Course.new
 
-        course = @assessment.create_assignment_group(course, @resources)
-        assert_equal course.assignment_groups.count, 1
+        result = AssignmentGroup.create_assignment_group("fake_group_name_123")
+        assert_equal result.class, CanvasCc::CanvasCC::Models::AssignmentGroup
       end
     end
 
@@ -110,12 +110,10 @@ describe Senkyoshi do
         quiz_type = "assignment"
         @assessment = @assessment.iterate_xml(xml.children.first, pre_data)
 
-        assignment = @assessment.create_assignment
+        assignment = @assessment.create_assignment(@assignment_group_id)
         assert_equal assignment.title,
                      (@assessment.instance_variable_get :@title)
         assert_equal (@assessment.instance_variable_get :@quiz_type), quiz_type
-        assert_equal assignment.assignment_group_identifier_ref,
-                     (@assessment.instance_variable_get :@group_id)
         assert_equal assignment.workflow_state,
                      (@assessment.instance_variable_get :@workflow_state)
         assert_equal assignment.points_possible,

--- a/spec/models/assignment_group_spec.rb
+++ b/spec/models/assignment_group_spec.rb
@@ -26,16 +26,16 @@ describe Senkyoshi do
 
     describe "canvas_conversion" do
       it "should create a canvas assignment_group" do
-        course = CanvasCc::CanvasCC::Models::Course.new
-        @assignment_group.canvas_conversion(course)
-        assert_equal course.assignment_groups.count, 1
+        result = @assignment_group.canvas_conversion
+        assert_equal(
+          result.class, CanvasCc::CanvasCC::Models::AssignmentGroup
+        )
       end
 
       it "should create a canvas assignment_group with correct details" do
-        course = CanvasCc::CanvasCC::Models::Course.new
-        @assignment_group.canvas_conversion(course)
-        assert_equal course.assignment_groups.first.title, @title
-        assert_equal course.assignment_groups.first.identifier, @group_id
+        result = @assignment_group.canvas_conversion
+        assert_equal result.title, @title
+        assert_equal result.identifier, @group_id
       end
     end
   end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -38,8 +38,7 @@ describe "Content" do
     it "should return an object with values" do
       xml = get_fixture_xml "content.xml"
       file_name = "res00023"
-      content = Content.new
-      result = content.get_pre_data(xml, file_name)
+      result = Content.get_pre_data(xml, file_name)
 
       id = xml.xpath("/CONTENT/@id").first.text
       parent_id = xml.xpath("/CONTENT/PARENTID/@value").first.text

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -30,7 +30,7 @@ describe "Gradebook" do
       xml = get_fixture_xml "gradebook.xml"
       pre_data = {}
 
-      results = @gradebook.get_pre_data(xml, pre_data).first
+      results = Gradebook.get_pre_data(xml, pre_data).first
 
       assert_equal results[:category], "Test"
       assert_equal results[:points], "50.0"
@@ -53,7 +53,8 @@ describe "Gradebook" do
   describe "get_outcome_definitions" do
     it "should return all outcome definitions" do
       xml = get_fixture_xml "gradebook.xml"
-      result = Gradebook.get_outcome_definitions xml
+      subject = Gradebook.new.iterate_xml(xml, nil)
+      result = subject.get_outcome_definitions xml
 
       assert_equal(result.size, 4)
       assert_equal(result.map(&:class).uniq, [Senkyoshi::OutcomeDefinition])
@@ -61,15 +62,16 @@ describe "Gradebook" do
   end
 
   it "should implement canvas_conversion" do
-    not_quiz = OutcomeDefinition.new(1, "", nil, nil)
-    quiz = OutcomeDefinition.new(2, "res001", nil, nil)
-
-    subject = Gradebook.new
-    subject.outcome_definitions = [not_quiz, quiz]
-
-    course = CanvasCc::CanvasCC::Models::Course.new
-    subject.canvas_conversion(course)
-    refute(course.assignments.size, 0)
+    # not_quiz = OutcomeDefinition.new("")
+    # quiz = OutcomeDefinition.new("res001")
+    #
+    # subject = Gradebook.new
+    # subject.outcome_definitions = [not_quiz, quiz]
+    # subject.categories = {asdf:"Category Name"}
+    #
+    # course = CanvasCc::CanvasCC::Models::Course.new
+    # subject.canvas_conversion(course)
+    # refute(course.assignments.size, 0)
     # TODO expect changes in course
   end
 end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -82,11 +82,24 @@ describe "Gradebook" do
     subject.canvas_conversion(course)
     assert_equal(course.assignments.size, 1)
     assert_equal(course.assignment_groups.size, 2)
-    assert(
-      course.assignment_groups.detect { |g| g.title == "Category One" },
-    )
-    assert(
-      course.assignment_groups.detect { |g| g.title == "Category Two" },
-    )
+    result = course.assignment_groups.map(&:title)
+    assert_equal(result, ["Category One", "Category Two"])
+  end
+
+  describe "convert_categories" do
+    it "only creates assignment groups once" do
+      subject = Gradebook.new
+      subject.categories = {
+        category_1: "Category One",
+        category_1: "Category One",
+        category_2: "Category Two",
+      }
+
+      course = CanvasCc::CanvasCC::Models::Course.new
+      subject.canvas_conversion(course)
+
+      result = course.assignment_groups.map(&:title)
+      assert_equal(result, ["Category One", "Category Two"])
+    end
   end
 end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -67,33 +67,36 @@ describe "Gradebook" do
     should_not_create_quiz = get_fixture_xml("outcome_definition.xml").
       xpath("./OUTCOMEDEFINITION").first
 
-    subject = Gradebook.new
-    subject.outcome_definitions = [
-      OutcomeDefinition.from(should_create_quiz, "Category One"),
-      OutcomeDefinition.from(should_not_create_quiz, "Category Two"),
-    ]
-
-    subject.categories = {
+    categories = {
       category_1: "Category One",
       category_2: "Category Two",
     }
 
+    outcome_definitions = [
+      OutcomeDefinition.from(should_create_quiz, "Category One"),
+      OutcomeDefinition.from(should_not_create_quiz, "Category Two"),
+    ]
+
+    subject = Gradebook.new(categories, outcome_definitions)
+
     course = CanvasCc::CanvasCC::Models::Course.new
     subject.canvas_conversion(course)
+    result = course.assignment_groups.map(&:title)
+
     assert_equal(course.assignments.size, 1)
     assert_equal(course.assignment_groups.size, 2)
-    result = course.assignment_groups.map(&:title)
     assert_equal(result, ["Category One", "Category Two"])
   end
 
   describe "convert_categories" do
     it "only creates assignment groups once" do
-      subject = Gradebook.new
-      subject.categories = {
+      categories = {
         category_1: "Category One",
         category_1: "Category One",
         category_2: "Category Two",
       }
+
+      subject = Gradebook.new(categories)
 
       course = CanvasCc::CanvasCC::Models::Course.new
       subject.canvas_conversion(course)

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -46,4 +46,17 @@ describe "Gradebook" do
       assert_equal(result.map(&:class).uniq, [Senkyoshi::OutcomeDefinition])
     end
   end
+
+  it "should implement canvas_conversion" do
+    not_quiz = OutcomeDefinition.new(1, "", nil, nil)
+    quiz = OutcomeDefinition.new(2, "res001", nil, nil)
+
+    subject = Gradebook.new
+    subject.outcome_definitions = [not_quiz, quiz]
+
+    course = CanvasCc::CanvasCC::Models::Course.new
+    subject.canvas_conversion(course)
+    refute(course.assignments.size, 0)
+    # TODO expect changes in course
+  end
 end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -22,7 +22,7 @@ describe "Gradebook" do
       pre_data = {}
       count = xml.search("OUTCOMEDEFINITIONS").children.length
 
-      results = @gradebook.get_pre_data(xml, pre_data)
+      results = Gradebook.get_pre_data(xml, pre_data)
       assert_equal(results.length, count)
     end
   end
@@ -32,7 +32,7 @@ describe "Gradebook" do
       xml = get_fixture_xml "gradebook.xml"
       count = xml.at("CATEGORIES").children.length
 
-      categories = @gradebook.get_categories(xml)
+      categories = Gradebook.get_categories(xml)
       assert_equal(categories.length, count)
     end
   end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -62,16 +62,31 @@ describe "Gradebook" do
   end
 
   it "should implement canvas_conversion" do
-    # not_quiz = OutcomeDefinition.new("")
-    # quiz = OutcomeDefinition.new("res001")
-    #
-    # subject = Gradebook.new
-    # subject.outcome_definitions = [not_quiz, quiz]
-    # subject.categories = {asdf:"Category Name"}
-    #
-    # course = CanvasCc::CanvasCC::Models::Course.new
-    # subject.canvas_conversion(course)
-    # refute(course.assignments.size, 0)
-    # TODO expect changes in course
+    should_create_quiz = get_fixture_xml("user_created_outcome_definition.xml").
+      xpath("./OUTCOMEDEFINITION").first
+    should_not_create_quiz = get_fixture_xml("outcome_definition.xml").
+      xpath("./OUTCOMEDEFINITION").first
+
+    subject = Gradebook.new
+    subject.outcome_definitions = [
+      OutcomeDefinition.from(should_create_quiz, "Category One"),
+      OutcomeDefinition.from(should_not_create_quiz, "Category Two"),
+    ]
+
+    subject.categories = {
+      category_1: "Category One",
+      category_2: "Category Two",
+    }
+
+    course = CanvasCc::CanvasCC::Models::Course.new
+    subject.canvas_conversion(course)
+    assert_equal(course.assignments.size, 1)
+    assert_equal(course.assignment_groups.size, 2)
+    assert(
+      course.assignment_groups.detect { |g| g.title == "Category One" },
+    )
+    assert(
+      course.assignment_groups.detect { |g| g.title == "Category Two" },
+    )
   end
 end

--- a/spec/models/gradebook_spec.rb
+++ b/spec/models/gradebook_spec.rb
@@ -36,4 +36,14 @@ describe "Gradebook" do
       assert_equal(categories.length, count)
     end
   end
+
+  describe "get_outcome_definitions" do
+    it "should return all outcome definitions" do
+      xml = get_fixture_xml "gradebook.xml"
+      result = Gradebook.get_outcome_definitions xml
+
+      assert_equal(result.size, 4)
+      assert_equal(result.map(&:class).uniq, [Senkyoshi::OutcomeDefinition])
+    end
+  end
 end

--- a/spec/models/outcome_definition_spec.rb
+++ b/spec/models/outcome_definition_spec.rb
@@ -8,7 +8,10 @@ require_relative "../../lib/senkyoshi/models/gradebook"
 describe "OutcomeDefinition" do
   it "should create self from xml" do
     xml = get_fixture_xml "outcome_definition.xml"
-    result = OutcomeDefinition.from_xml(xml.xpath("./OUTCOMEDEFINITION").first)
+    category_id = "asdf123"
+    result = OutcomeDefinition.from(
+      xml.xpath("./OUTCOMEDEFINITION").first, category_id
+    )
 
     assert_equal(result.id, "_3006852_1")
     assert_equal(result.content_id, "res00021")

--- a/spec/models/outcome_definition_spec.rb
+++ b/spec/models/outcome_definition_spec.rb
@@ -17,6 +17,18 @@ describe "OutcomeDefinition" do
     assert_equal(result.content_id, "res00021")
   end
 
-  # it "should implement canvas_conversion" do
-  # end
+  it "should implement canvas_conversion" do
+    xml = get_fixture_xml("outcome_definition.xml").
+      xpath("./OUTCOMEDEFINITION").first
+    subject = OutcomeDefinition.from(xml, "category_name")
+
+    course = CanvasCc::CanvasCC::Models::Course.new
+    subject.canvas_conversion(course)
+
+    result = course.assignments.first
+
+    assert_equal(course.assignments.size, 1)
+    assert_equal(result.title, "All the things")
+    assert_equal(result.points_possible, "50.0")
+  end
 end

--- a/spec/models/outcome_definition_spec.rb
+++ b/spec/models/outcome_definition_spec.rb
@@ -1,0 +1,19 @@
+require "minitest/autorun"
+require "senkyoshi"
+require "pry"
+
+require_relative "../helpers.rb"
+require_relative "../../lib/senkyoshi/models/gradebook"
+
+describe "OutcomeDefinition" do
+  it "should create self from xml" do
+    xml = get_fixture_xml "outcome_definition.xml"
+    result = OutcomeDefinition.from_xml(xml.xpath("./OUTCOMEDEFINITION").first)
+
+    assert_equal(result.id, "_3006852_1")
+    assert_equal(result.content_id, "res00021")
+  end
+
+  # it "should implement canvas_conversion" do
+  # end
+end

--- a/spec/models/qti_spec.rb
+++ b/spec/models/qti_spec.rb
@@ -146,7 +146,7 @@ describe Senkyoshi do
     describe "get_pre_data" do
       it "should set the values in the pre_data" do
         xml = get_fixture_xml "course_assessment.xml"
-        results = @assessment.class.get_pre_data(xml, {})
+        results = QTI.get_pre_data(xml, {})
 
         assert_equal results[:original_file_name], "res00048"
         assert_equal results[:time_limit], "20"
@@ -288,7 +288,7 @@ describe Senkyoshi do
 
     describe "create_assignment_group" do
       it "should create assignment group" do
-        result = AssignmentGroup.create_assignment_group("fake_group_name")
+        result = AssignmentGroup.create_assignment_group(@assignment_group_id)
         assert_equal result.class, CanvasCc::CanvasCC::Models::AssignmentGroup
       end
     end
@@ -303,6 +303,8 @@ describe Senkyoshi do
         assert_equal (@assessment.instance_variable_get :@quiz_type), quiz_type
         assert_equal assignment.workflow_state,
                      (@assessment.instance_variable_get :@workflow_state)
+        assert_equal assignment.assignment_group_identifier_ref,
+                     @assignment_group_id
         assert_equal assignment.points_possible,
                      (@assessment.instance_variable_get :@points_possible)
         assert_equal assignment.position, 1

--- a/spec/models/qti_spec.rb
+++ b/spec/models/qti_spec.rb
@@ -13,6 +13,7 @@ describe Senkyoshi do
       pre_data = {}
       @assessment = QTI.from(xml.children.first, pre_data)
       @resources = Senkyoshi::Collection.new
+      @assignment_group_id = "fake_assn_id"
     end
 
     describe "initialize" do
@@ -145,7 +146,7 @@ describe Senkyoshi do
     describe "get_pre_data" do
       it "should set the values in the pre_data" do
         xml = get_fixture_xml "course_assessment.xml"
-        results = @assessment.get_pre_data(xml, {})
+        results = @assessment.class.get_pre_data(xml, {})
 
         assert_equal results[:original_file_name], "res00048"
         assert_equal results[:time_limit], "20"
@@ -174,7 +175,7 @@ describe Senkyoshi do
         description = "<p>Do this test with honor</p>"
         instructions = "<p>Don't forget your virtue</p>"
 
-        assignment = @assessment.create_assignment
+        assignment = @assessment.create_assignment(@assignment_group_id)
         assessment =
           @assessment.setup_assessment(assessment, assignment, @resources)
         assert_equal assessment.title, title
@@ -188,7 +189,7 @@ describe Senkyoshi do
         empty_quiz = QTI.from(xml.children.first, pre_data)
         assessment = CanvasCc::CanvasCC::Models::Assessment.new
 
-        assignment = empty_quiz.create_assignment
+        assignment = empty_quiz.create_assignment(@assignment_group_id)
         assessment =
           empty_quiz.setup_assessment(assessment, assignment, @resources)
         assert_equal (empty_quiz.instance_variable_get :@items).count, 0
@@ -286,11 +287,9 @@ describe Senkyoshi do
     end
 
     describe "create_assignment_group" do
-      it "should create assignment groups in course" do
-        course = CanvasCc::CanvasCC::Models::Course.new
-
-        course = @assessment.create_assignment_group(course, @resources)
-        assert_equal course.assignment_groups.count, 1
+      it "should create assignment group" do
+        result = AssignmentGroup.create_assignment_group("fake_group_name")
+        assert_equal result.class, CanvasCc::CanvasCC::Models::AssignmentGroup
       end
     end
 
@@ -298,12 +297,10 @@ describe Senkyoshi do
       it "should create an assignment" do
         quiz_type = "assignment"
 
-        assignment = @assessment.create_assignment
+        assignment = @assessment.create_assignment(@assignment_group_id)
         assert_equal assignment.title,
                      (@assessment.instance_variable_get :@title)
         assert_equal (@assessment.instance_variable_get :@quiz_type), quiz_type
-        assert_equal assignment.assignment_group_identifier_ref,
-                     (@assessment.instance_variable_get :@group_id)
         assert_equal assignment.workflow_state,
                      (@assessment.instance_variable_get :@workflow_state)
         assert_equal assignment.points_possible,

--- a/spec/models/survey_spec.rb
+++ b/spec/models/survey_spec.rb
@@ -11,6 +11,7 @@ describe Senkyoshi do
     before do
       @survey = Survey.new
       @resources = Senkyoshi::Collection.new
+      @assignment_group_id = 5
     end
 
     describe "initialize" do
@@ -70,7 +71,7 @@ describe Senkyoshi do
         description = "<p>Do this test with honor</p>"
         instructions = "<p>Don't forget your virtue</p>"
 
-        assignment = @survey.create_assignment
+        assignment = @survey.create_assignment(@assignment_group_id)
         assessment =
           @survey.setup_assessment(assessment, assignment, @resources)
         assert_equal assessment.title, title
@@ -93,14 +94,14 @@ describe Senkyoshi do
     end
 
     describe "create_assignment_group" do
-      it "should create assignment groups in course" do
+      it "should create assignment group" do
         xml = get_fixture_xml "survey.xml"
         pre_data = {}
+        group_name = "fake_group"
         @survey = @survey.iterate_xml(xml.children.first, pre_data)
-        course = CanvasCc::CanvasCC::Models::Course.new
 
-        course = @survey.create_assignment_group(course, @resources)
-        assert_equal course.assignment_groups.count, 1
+        result = AssignmentGroup.create_assignment_group(group_name)
+        assert_equal(result.class, CanvasCc::CanvasCC::Models::AssignmentGroup)
       end
     end
 
@@ -111,13 +112,13 @@ describe Senkyoshi do
         quiz_type = "graded_survey"
         @survey = @survey.iterate_xml(xml.children.first, pre_data)
 
-        assignment = @survey.create_assignment
+        assignment = @survey.create_assignment(@assignment_group_id)
         assert_equal assignment.title,
                      (@survey.instance_variable_get :@title)
         assert_equal quiz_type,
                      (@survey.instance_variable_get :@quiz_type)
         assert_equal assignment.assignment_group_identifier_ref,
-                     (@survey.instance_variable_get :@group_id)
+                     @assignment_group_id
         assert_equal assignment.workflow_state,
                      (@survey.instance_variable_get :@workflow_state)
         assert_equal assignment.points_possible,


### PR DESCRIPTION
* Creates assignments for user created gradebook entries that aren't linked to any other content
* Converts all assignment groups listed in blackboard gradebook


Below is an example of converted assignments and assignment groups. This mirrors the behavior of the Instructure converter. The below image was captured after converting: ExportFile_AU014_16BC.Summer.2016.CCC_MAFCLC003_1_20161028012650.zip

<img width="1071" alt="screen shot 2017-01-12 at 4 46 15 pm" src="https://cloud.githubusercontent.com/assets/9383215/21912989/bd6b9486-d8e6-11e6-984a-fc0bd64683b8.png">
