### PR TITLE
Add Partial Support for Course Links

### DIFF
--- a/lib/senkyoshi/models/content.rb
+++ b/lib/senkyoshi/models/content.rb
@@ -20,6 +20,7 @@ module Senkyoshi
       "x-bb-module-page" => "WikiPage",
       "x-bb-lesson-plan" => "WikiPage",
       "x-bb-syllabus" => "WikiPage",
+      "x-bb-courselink" => "WikiPage",
     }.freeze
 
     MODULE_TYPES = {
@@ -67,6 +68,7 @@ module Senkyoshi
       @type = xml.xpath("/CONTENT/RENDERTYPE/@value").first.text
       @parent_id = pre_data[:parent_id]
       @module_type = MODULE_TYPES[self.class.name]
+      @referred_to_title = pre_data[:referred_to_title]
 
       if pre_data[:assignment_id] && !pre_data[:assignment_id].empty?
         @id = pre_data[:assignment_id]

--- a/lib/senkyoshi/models/link.rb
+++ b/lib/senkyoshi/models/link.rb
@@ -1,0 +1,14 @@
+module Senkyoshi
+  ##
+  # Represents a link between Blackboard resources.
+  ##
+  class Link < FileResource
+    def self.get_pre_data(xml_data, _file)
+      {
+        title: xml_data.children.at("TITLE").attributes["value"].value,
+        referrer: xml_data.children.at("REFERRER").attributes["id"].value,
+        referred_to: xml_data.children.at("REFERREDTO").attributes["id"].value,
+      }
+    end
+  end
+end

--- a/lib/senkyoshi/models/link.rb
+++ b/lib/senkyoshi/models/link.rb
@@ -5,9 +5,10 @@ module Senkyoshi
   class Link < FileResource
     def self.get_pre_data(xml_data, _file)
       {
-        title: xml_data.children.at("TITLE").attributes["value"].value,
         referrer: xml_data.children.at("REFERRER").attributes["id"].value,
         referred_to: xml_data.children.at("REFERREDTO").attributes["id"].value,
+        referred_to_title: xml_data.children.at("TITLE").
+          attributes["value"].value,
       }
     end
   end

--- a/lib/senkyoshi/models/wikipage.rb
+++ b/lib/senkyoshi/models/wikipage.rb
@@ -35,10 +35,19 @@ module Senkyoshi
 
     def _set_body(original_body, url, extendeddata)
       body = original_body.dup
+
       if !url.empty?
         body = %{
           <a href="#{url}">
             #{url}
+          </a>
+          #{body}
+        }
+      end
+      if @referred_to_title.present?
+        body = %{
+          <a href="$CANVAS_COURSE_REFERENCE$#{@referred_to_title}">
+            Course Link: #{@referred_to_title}
           </a>
           #{body}
         }
@@ -49,6 +58,7 @@ module Senkyoshi
           #{_extendeddata(extendeddata)}
         }
       end
+
       body
     end
 

--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -37,6 +37,7 @@ require "senkyoshi/models/file"
 require "senkyoshi/models/forum"
 require "senkyoshi/models/gradebook"
 require "senkyoshi/models/group"
+require "senkyoshi/models/link"
 require "senkyoshi/models/module"
 require "senkyoshi/models/module_item"
 require "senkyoshi/models/qti"
@@ -65,6 +66,7 @@ module Senkyoshi
   PRE_RESOURCE_TYPE = {
     coursetoc: "CourseToc",
     gradebook: "Gradebook",
+    link: "Link",
     courseassessment: "QTI",
   }.freeze
 
@@ -85,8 +87,8 @@ module Senkyoshi
   end
 
   def self.get_single_pre_data(pre_data, file)
-    pre_data.detect do |d|
-      d[:file_name] == file || d[:assignment_id] == file
+    pre_data.detect do |data_item|
+      data_item[:file_name] == file || data_item[:assignment_id] == file
     end || { file_name: file }
   end
 
@@ -129,6 +131,13 @@ module Senkyoshi
         course_assessment = pre_data["courseassessment"].
           detect { |ca| ca[:original_file_name] == content[:assignment_id] }
         content.merge!(course_assessment) if course_assessment
+      end
+      if pre_data["link"]
+        matching_link = pre_data["link"].detect do |link|
+          link[:referrer] == content[:file_name]
+        end
+
+        content[:referred_to_title] = matching_link[:title] if matching_link
       end
     end
     pre_data["content"]

--- a/lib/senkyoshi/xml_parser.rb
+++ b/lib/senkyoshi/xml_parser.rb
@@ -127,19 +127,24 @@ module Senkyoshi
           detect { |g| g[:content_id] == content[:file_name] }
         content.merge!(gradebook) if gradebook
       end
+
       if pre_data["courseassessment"]
         course_assessment = pre_data["courseassessment"].
           detect { |ca| ca[:original_file_name] == content[:assignment_id] }
         content.merge!(course_assessment) if course_assessment
       end
+
       if pre_data["link"]
         matching_link = pre_data["link"].detect do |link|
           link[:referrer] == content[:file_name]
         end
 
-        content[:referred_to_title] = matching_link[:title] if matching_link
+        if matching_link
+          content[:referred_to_title] = matching_link[:referred_to_title]
+        end
       end
     end
+
     pre_data["content"]
   end
 

--- a/spec/fixtures/link.xml
+++ b/spec/fixtures/link.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LINK id="_2271489_1">
+  <TITLE value="/Content/Test Test"/>
+  <FLAGS>
+    <ISAVAILABLE value="true"/>
+  </FLAGS>
+  <REFERRER id="res00053" type="CONTENT"/>
+  <REFERREDTO id="res00030" type="CONTENT"/>
+</LINK>

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,20 @@
+require "minitest/autorun"
+require "senkyoshi"
+require "pry"
+
+require_relative "../../lib/senkyoshi/models/link"
+
+include Senkyoshi
+
+describe Senkyoshi do
+  describe "get_pre_data" do
+    it "should return the correct data" do
+      link_xml = get_fixture_xml "link.xml"
+      link_pre_data = Link.get_pre_data(link_xml, nil)
+
+      assert_equal("/Content/Test Test", link_pre_data[:title])
+      assert_equal("res00053", link_pre_data[:referrer])
+      assert_equal("res00030", link_pre_data[:referred_to])
+    end
+  end
+end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -12,9 +12,9 @@ describe Senkyoshi do
       link_xml = get_fixture_xml "link.xml"
       link_pre_data = Link.get_pre_data(link_xml, nil)
 
-      assert_equal("/Content/Test Test", link_pre_data[:title])
       assert_equal("res00053", link_pre_data[:referrer])
       assert_equal("res00030", link_pre_data[:referred_to])
+      assert_equal("/Content/Test Test", link_pre_data[:referred_to_title])
     end
   end
 end

--- a/spec/models/wikipage_spec.rb
+++ b/spec/models/wikipage_spec.rb
@@ -9,39 +9,45 @@ describe "WikiPage" do
   before do
     @xml = get_fixture_xml "content.xml"
     @id = "res001"
-    @pre_data = { file_name: @id }
-  end
-  it "should iterate_xml" do
-    page = Senkyoshi::WikiPage.new(@id)
-    page.iterate_xml(@xml, @pre_data)
+    @pre_data = { file_name: @id, referred_to_title: "/Content/Test Test" }
+    @page = Senkyoshi::WikiPage.new(@id)
 
+    @page.iterate_xml(@xml, @pre_data)
+  end
+
+  it "should iterate_xml" do
     page_title = @xml.xpath("/CONTENT/TITLE/@value").first.text
     page_body = @xml.xpath("/CONTENT/BODY/TEXT").first.text
 
-    assert_equal(page.id, @id)
-    assert_equal(page.title, page_title)
-    assert_equal(page.body, page_body)
-    assert_equal(page.files.length, 1)
-    assert_equal(page.files.first.id, "_2030185_1")
+    assert_equal(@page.id, @id)
+    assert_equal(@page.title, page_title)
+    assert_equal(@page.body, page_body)
+    assert_equal(@page.files.length, 1)
+    assert_equal(@page.files.first.id, "_2030185_1")
   end
 
   it "should convert to canvas wiki page" do
     course = CanvasCc::CanvasCC::Models::Course.new
-    page = Senkyoshi::WikiPage.new(@id)
-    page.iterate_xml(@xml, @pre_data)
 
-    result = page.canvas_conversion(course, Senkyoshi::Collection.new)
+    result = @page.canvas_conversion(course, Senkyoshi::Collection.new)
 
     assert_equal(result.pages.size, 1)
     assert_equal(result.pages.first.identifier, @id)
   end
 
   it "should include extended data" do
-    page = Senkyoshi::WikiPage.new(@id)
-
-    page.iterate_xml(@xml, @pre_data)
-
     page_extendeddata = @xml.at("/CONTENT/EXTENDEDDATA/ENTRY").text
-    assert_equal page.extendeddata, page_extendeddata
+    assert_equal @page.extendeddata, page_extendeddata
+  end
+
+  it "should include course link in body" do
+    course = CanvasCc::CanvasCC::Models::Course.new
+    course = @page.canvas_conversion(course, Senkyoshi::Collection.new)
+
+    page_body = course.pages.first.body.gsub(/\s+/, " ")
+    expected_link_text = '<a href="%24CANVAS_COURSE_REFERENCE%24/Content/' \
+      'Test%20Test"> Course Link: /Content/Test Test </a>'
+
+    assert_includes(page_body, expected_link_text)
   end
 end

--- a/spec/xml_parser_spec.rb
+++ b/spec/xml_parser_spec.rb
@@ -82,6 +82,29 @@ describe Senkyoshi do
       assert_equal data[:parent_id], parent_id
     end
 
+    it "should return a merged content object with links" do
+      file_name_one = "res00028"
+      file_name_two = "res00036"
+      pre_data = {}
+
+      pre_data["content"] = [
+        { file_name: file_name_one },
+        { file_name: file_name_two },
+      ]
+
+      pre_data["link"] = [
+        {
+          title: "/Content/Test Item",
+          referrer: file_name_one,
+          referred_to: file_name_two,
+        },
+      ]
+
+      results = Senkyoshi.connect_content(pre_data)
+      content = results.detect { |result| result[:file_name] == file_name_one }
+      assert_equal(content[:referred_to_title], "/Content/Test Item")
+    end
+
     it "should return a merged content object" do
       file_name = "res00003"
       parent_id = "res00002"

--- a/spec/xml_parser_spec.rb
+++ b/spec/xml_parser_spec.rb
@@ -94,9 +94,9 @@ describe Senkyoshi do
 
       pre_data["link"] = [
         {
-          title: "/Content/Test Item",
           referrer: file_name_one,
           referred_to: file_name_two,
+          referred_to_title: "/Content/Test Item",
         },
       ]
 


### PR DESCRIPTION
This adds partial support for the course link content type from Blackboard. Senkyoshi turns the Blackboard course link into a Canvas wiki page and embeds a link in the page body. The link is not valid, but it provides enough information for the course editor to find the resource it should link to and fix it manually.