### PR TITLE
Fix Question Bank Description Bug [#138873885]

### DIFF
--- a/lib/senkyoshi/models/question_bank.rb
+++ b/lib/senkyoshi/models/question_bank.rb
@@ -18,10 +18,6 @@ module Senkyoshi
     end
 
     def setup_question_bank(question_bank, resources)
-      if @items.count.zero?
-        question_bank.description += "Empty Quiz -- No questions
-          were contained in the blackboard quiz bank"
-      end
       question_bank = create_items(question_bank, resources)
       question_bank
     end


### PR DESCRIPTION
Senkyoshi was attempting to set the description on question banks with no questions. This was resulting in a NoMethodError. 

Question banks don't have descriptions as far as I can tell. There's no way to add one in the Canvas UI, and the canvas_cc gem doesn't support descriptions for question banks.

I removed the code that was attempting to set the quiz bank description.