### PR TITLE
Fix UTF-8, ASCII-8BIT Compatibility Error [#139953217]

### DIFF
--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -10,10 +10,16 @@ module Senkyoshi
     ].freeze
 
     def initialize(zip_entry)
-      @path = strip_xid zip_entry.name.force_encoding("UTF-8")
+      begin
+        entry_name = zip_entry.name.encode("UTF-8")
+      rescue Encoding::UndefinedConversionError
+        entry_name = zip_entry.name.force_encoding("UTF-8")
+      end
+
+      @path = strip_xid entry_name
       @location = extract_file(zip_entry) # Location of file on local filesystem
 
-      base_name = File.basename(zip_entry.name.force_encoding("UTF-8"))
+      base_name = File.basename(entry_name)
       @xid = base_name[/__(xid-[0-9]+_[0-9]+)/, 1] ||
         Senkyoshi.create_random_hex
     end

--- a/lib/senkyoshi/models/file.rb
+++ b/lib/senkyoshi/models/file.rb
@@ -10,10 +10,10 @@ module Senkyoshi
     ].freeze
 
     def initialize(zip_entry)
-      @path = strip_xid zip_entry.name
+      @path = strip_xid zip_entry.name.force_encoding("UTF-8")
       @location = extract_file(zip_entry) # Location of file on local filesystem
 
-      base_name = File.basename(zip_entry.name)
+      base_name = File.basename(zip_entry.name.force_encoding("UTF-8"))
       @xid = base_name[/__(xid-[0-9]+_[0-9]+)/, 1] ||
         Senkyoshi.create_random_hex
     end

--- a/spec/models/file_spec.rb
+++ b/spec/models/file_spec.rb
@@ -12,6 +12,17 @@ describe "SenkyoshiFile" do
     @file = Senkyoshi::SenkyoshiFile.new(entry)
   end
 
+  it "should force UTF-8 encoding for @xid and @path" do
+    # ASCII encoding from zip_entry.
+    zip_entry = get_zip_fixture("empty_dat.zip") { |zip| zip.entries.first }
+    assert_equal("ASCII-8BIT", zip_entry.name.encoding.to_s)
+
+    # UTF-8 encoding forced by SenkyoshiFile#initialize.
+    file = Senkyoshi::SenkyoshiFile.new(zip_entry)
+    assert_equal("UTF-8", file.xid.encoding.to_s)
+    assert_equal("UTF-8", file.path.encoding.to_s)
+  end
+
   it "should iterate_xml" do
     assert_equal(@file.xid, "xid-1234_1")
     assert_equal(@file.path, "fake/path/to/file.txt")


### PR DESCRIPTION
`Zip::Entry#name` returns an ASCII-8BIT encoded string. Instances of `SenkyoshiFile` had this encoding for the strings in `@xid` and `@path`. That had the potential to cause compatibility issues. This forces UTF-8 encoding on those instance variables.

It's worth noting that `Zip::Entry#name` is called elsewhere by Senkyoshi. It might be necessary to force UTF-8 encoding in other places as well. I chose just to fix the issue we were actually experiencing for now.