### PR TITLE
Remove unnecessary fileutils gem.

### DIFF
--- a/senkyoshi.gemspec
+++ b/senkyoshi.gemspec
@@ -29,7 +29,6 @@ Gem::Specification.new do |spec|
     ["rake", "~> 11.3"],
     ["rubyzip", "~> 1.1"],
     ["nokogiri", "~> 1.6.6"],
-    ["fileutils", "~> 0.7"],
     ["pandarus", "~> 0.6"],
     ["activesupport", "~> 4.2"],
     ["rest-client", "~> 2.0"],


### PR DESCRIPTION
This is already included with ruby and we don’t need to include it here.