### PR TITLE
Update to allow customizing the oauth consumer key for scorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Create a `senkyoshi.yml` and add credentials:
 # Adhesion, this will look like https://<adhesion url>/scorm_course
 :scorm_launch_url: <scorm launch url>
 
+# This should be the oauth_consumer_key for scorm. In the case of
+# Adhesion, it would just be `scorm`.
+:scorm_oauth_consumer_key: <scorm oauth consumer key>
+
 # This is the secret to authenticate requests to the SCORM manager. In the case
 # of Adhesion, you can generate a shared secret by logging into the server and
 # running rake shared_auth, which will generate and save a token

--- a/lib/senkyoshi/canvas_course.rb
+++ b/lib/senkyoshi/canvas_course.rb
@@ -151,7 +151,7 @@ module Senkyoshi
         RestClient.post(
           "#{Senkyoshi.configuration.scorm_url}/api/scorm_courses",
           {
-            oauth_consumer_key: "scorm-player",
+            oauth_consumer_key: Senkyoshi.configuration.scorm_oauth_consumer_key,
             lms_course_id: course_id,
             file: file,
           },

--- a/lib/senkyoshi/canvas_course.rb
+++ b/lib/senkyoshi/canvas_course.rb
@@ -147,15 +147,16 @@ module Senkyoshi
     ##
     def upload_scorm_package(scorm_package, course_id, tmp_name)
       zip = scorm_package.write_zip tmp_name
+      config = Senkyoshi.configuration
       File.open(zip, "rb") do |file|
         RestClient.post(
           "#{Senkyoshi.configuration.scorm_url}/api/scorm_courses",
           {
-            oauth_consumer_key: Senkyoshi.configuration.scorm_oauth_consumer_key,
+            oauth_consumer_key: config.scorm_oauth_consumer_key,
             lms_course_id: course_id,
             file: file,
           },
-          SharedAuthorization: Senkyoshi.configuration.scorm_shared_auth,
+          SharedAuthorization: config.scorm_shared_auth,
         ) do |resp|
           result = JSON.parse(resp.body)["response"]
           result["points_possible"] = scorm_package.points_possible

--- a/lib/senkyoshi/version.rb
+++ b/lib/senkyoshi/version.rb
@@ -14,5 +14,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 module Senkyoshi
-  VERSION = "1.0.9".freeze
+  VERSION = "1.0.10".freeze
 end

--- a/senkyoshi.yml.example
+++ b/senkyoshi.yml.example
@@ -2,5 +2,6 @@
 :canvas_token: <canvas token>
 :scorm_url: <scorm manager url>
 :scorm_launch_url: <scorm launch url>
+:scorm_oauth_consumer_key: <scorm oauth consumer key>
 :scorm_shared_auth: <scorm manager token>
 :request_timeout: <request timeout seconds>


### PR DESCRIPTION
The problem right now with this gem, is the oauth consumer key has changed in Adhesion, so this is now broken. This allows you to set this value as you need it.